### PR TITLE
Add `defang` format string specifier

### DIFF
--- a/flow/record/fieldtypes/__init__.py
+++ b/flow/record/fieldtypes/__init__.py
@@ -30,6 +30,19 @@ float_type = float
 path_type = pathlib.PurePath
 
 
+def defang(value: str) -> str:
+    """Defangs the value to make URLs or ip addresses unclickable"""
+    value = re.sub("^http://", "hxxp://", value, flags=re.IGNORECASE)
+    value = re.sub("^https://", "hxxps://", value, flags=re.IGNORECASE)
+    value = re.sub("^ftp://", "fxp://", value, flags=re.IGNORECASE)
+    value = re.sub("^file://", "fxle://", value, flags=re.IGNORECASE)
+    value = re.sub("^ldap://", "ldxp://", value, flags=re.IGNORECASE)
+    value = re.sub("^ldaps://", "ldxps://", value, flags=re.IGNORECASE)
+    value = re.sub(r"(\w+)\.(\w+)($|/|:)", r"\1[.]\2\3", value, flags=re.IGNORECASE)
+    value = re.sub(r"(\d+)\.(\d+)\.(\d+)\.(\d+)", r"\1.\2.\3[.]\4", value, flags=re.IGNORECASE)
+    return value
+
+
 def fieldtype_for_value(value, default="string"):
     """Returns fieldtype name derived from the value. Returns `default` if it cannot be derived.
 
@@ -155,6 +168,11 @@ class string(string_type, FieldType):
 
     def _pack(self):
         return self
+
+    def __format__(self, spec):
+        if spec == "defang":
+            return defang(self)
+        return str.__format__(self, spec)
 
     @classmethod
     def _decode(cls, data, encoding):

--- a/flow/record/fieldtypes/net/ip.py
+++ b/flow/record/fieldtypes/net/ip.py
@@ -1,5 +1,6 @@
 from ipaddress import ip_address, ip_network
 from flow.record.base import FieldType
+from flow.record.fieldtypes import defang
 
 
 class ipaddress(FieldType):
@@ -20,6 +21,11 @@ class ipaddress(FieldType):
 
     def __repr__(self):
         return "{}({!r})".format(self._type, str(self))
+
+    def __format__(self, spec):
+        if spec == "defang":
+            return defang(str(self))
+        return str.__format__(str(self), spec)
 
     def _pack(self):
         return int(self.val)

--- a/tests/test_fieldtypes.py
+++ b/tests/test_fieldtypes.py
@@ -585,5 +585,41 @@ def test_dynamic():
     assert isinstance(r.value, flow.record.fieldtypes.posix_path)
 
 
+@pytest.mark.parametrize(
+    "record_type,value,expected",
+    [
+        ("uri", "https://www.fox-it.com/nl-en/dissect/", "hxxps://www.fox-it[.]com/nl-en/dissect/"),
+        ("string", "https://www.fox-it.com/nl-en/dissect/", "hxxps://www.fox-it[.]com/nl-en/dissect/"),
+        ("uri", "http://docs.dissect.tools", "hxxp://docs.dissect[.]tools"),
+        (
+            "string",
+            "http://username:password@example.com/path/file.txt?query=1",
+            "hxxp://username:password@example[.]com/path/file.txt?query=1",
+        ),
+        ("net.ipaddress", "1.3.3.7", "1.3.3[.]7"),
+        ("string", "www.fox-it.com", "www.fox-it[.]com"),
+        ("string", "dissect.tools", "dissect[.]tools"),
+        ("uri", "HTtPs://SpOngEbOB.cOm", "hxxps://SpOngEbOB[.]cOm"),
+        ("uri", "ftp://user:password@127.0.0.1:21/", "fxp://user:password@127.0.0[.]1:21/"),
+        (
+            "uri",
+            "https://isc.sans.edu/forums/diary/Defang+all+the+things/22744/",
+            "hxxps://isc.sans[.]edu/forums/diary/Defang+all+the+things/22744/",
+        ),
+    ],
+)
+def test_format_defang(record_type, value, expected):
+    TestRecord = RecordDescriptor(
+        "test/format/defang",
+        [
+            (record_type, "value"),
+        ],
+    )
+
+    record = TestRecord(value)
+    assert f"{record.value:defang}" == expected
+    assert f"{record.value:>100}" == f"{value:>100}"
+
+
 if __name__ == "__main__":
     __import__("standalone_test").main(globals())


### PR DESCRIPTION
This allows an user to `defang` the value on the following fieldtypes:

 * `string` and everything that subclasses it, eg: `uri`, `wstring`
 * net.ipaddress

The `defang` specifier is mainly useful when using `rdump` with the `--format` argument:

 $ rdump test.record
 <test/record domain='www.fox-it.com'>

 $ rdump -f "domain: {domain:defang}"
 domain: www.fox-it[.]com