### PR TITLE
Don't output RecordDescriptor information in JSON output of `rdump`

### DIFF
--- a/flow/record/adapter/jsonfile.py
+++ b/flow/record/adapter/jsonfile.py
@@ -9,7 +9,7 @@ from flow.record.fieldtypes import fieldtype_for_value
 __usage__ = """
 JSON adapter
 ---
-Write usage: rdump -w jsonfile://[PATH]?indent=[INDENT]&?descriptors=[DESCRIPTORS]
+Write usage: rdump -w jsonfile://[PATH]?indent=[INDENT]&descriptors=[DESCRIPTORS]
 Read usage: rdump jsonfile://[PATH]
 [PATH]: path to file. Leave empty or "-" to output to stdout
 [INDENT]: optional number of identation. Omit "indent" field value for jsonlines output

--- a/flow/record/adapter/jsonfile.py
+++ b/flow/record/adapter/jsonfile.py
@@ -9,22 +9,25 @@ from flow.record.fieldtypes import fieldtype_for_value
 __usage__ = """
 JSON adapter
 ---
-Write usage: rdump -w jsonfile://[PATH]?indent=[INDENT]
+Write usage: rdump -w jsonfile://[PATH]?indent=[INDENT]&?descriptors=[DESCRIPTORS]
 Read usage: rdump jsonfile://[PATH]
 [PATH]: path to file. Leave empty or "-" to output to stdout
 [INDENT]: optional number of identation. Omit "indent" field value for jsonlines output
+[DESCRIPTORS]: optional boolean. If false, don't output record descriptors (default: true)
 """
 
 
 class JsonfileWriter(AbstractWriter):
     fp = None
 
-    def __init__(self, path, indent=None, **kwargs):
+    def __init__(self, path, indent=None, descriptors=True, **kwargs):
+        self.descriptors = str(descriptors).lower() in ("true", "1")
         self.fp = record.open_path(path, "w")
         if isinstance(indent, str):
             indent = int(indent)
-        self.packer = JsonRecordPacker(indent=indent)
-        self.packer.on_descriptor.add_handler(self.packer_on_new_descriptor)
+        self.packer = JsonRecordPacker(indent=indent, pack_descriptors=self.descriptors)
+        if self.descriptors:
+            self.packer.on_descriptor.add_handler(self.packer_on_new_descriptor)
 
     def packer_on_new_descriptor(self, descriptor):
         self._write(descriptor)
@@ -70,7 +73,9 @@ class JsonfileReader(AbstractReader):
             else:
                 # fallback for plain jsonlines (non flow.record format)
                 jd = json.loads(line)
-                fields = [(fieldtype_for_value(val, "string"), key) for key, val in jd.items()]
+                fields = [
+                    (fieldtype_for_value(val, "string"), key) for key, val in jd.items() if not key.startswith("_")
+                ]
                 desc = record.RecordDescriptor("json/record", fields)
                 obj = desc(**jd)
                 if not self.selector or self.selector.match(obj):

--- a/flow/record/jsonpacker.py
+++ b/flow/record/jsonpacker.py
@@ -11,9 +11,10 @@ log = logging.getLogger(__package__)
 
 
 class JsonRecordPacker:
-    def __init__(self, indent=None):
+    def __init__(self, indent=None, pack_descriptors=True):
         self.descriptors = {}
         self.on_descriptor = EventHandler()
+        self.pack_descriptors = pack_descriptors
         self.indent = indent
 
     def register(self, desc, notify=False):
@@ -39,8 +40,9 @@ class JsonRecordPacker:
             if obj._desc.identifier not in self.descriptors:
                 self.register(obj._desc, True)
             serial = obj._asdict()
-            serial["_type"] = "record"
-            serial["_recorddescriptor"] = obj._desc.identifier
+            if self.pack_descriptors:
+                serial["_type"] = "record"
+                serial["_recorddescriptor"] = obj._desc.identifier
 
             # PYTHON2: Because "bytes" are also "str" we have to handle this here
             for (field_type, field_name) in obj._desc.get_field_tuples():

--- a/flow/record/tools/rdump.py
+++ b/flow/record/tools/rdump.py
@@ -167,8 +167,8 @@ def main():
     if not args.writer:
         mode_to_uri = {
             "csv": "csvfile://",
-            "json": "jsonfile://?indent=2",
-            "jsonlines": "jsonfile://",
+            "json": "jsonfile://?indent=2&descriptors=false",
+            "jsonlines": "jsonfile://?descriptors=false",
             "line": "line://",
         }
         uri = mode_to_uri.get(args.mode, uri)

--- a/tests/test_rdump.py
+++ b/tests/test_rdump.py
@@ -217,8 +217,8 @@ def test_rdump_json_no_descriptors(tmp_path):
                     count=i,
                     foo="bar" * i,
                     data=b"\x00\x01\x02\x03--" + data,
-                    ip="172.16.0.{}".format(i),
-                    subnet="192.168.{}.0/24".format(i),
+                    ip=f"172.16.0.{i}",
+                    subnet=f"192.168.{i}.0/24",
                     digest=(md5, sha1, sha256),
                 )
             )

--- a/tests/test_rdump.py
+++ b/tests/test_rdump.py
@@ -239,8 +239,8 @@ def test_rdump_json_no_descriptors(tmp_path):
         assert "_source" in json_dict
         data = str(i).encode()
         assert json_dict["data"] == base64.b64encode(b"\x00\x01\x02\x03--" + data).decode()
-        assert json_dict["ip"] == "172.16.0.{}".format(i)
-        assert json_dict["subnet"] == "192.168.{}.0/24".format(i)
+        assert json_dict["ip"] == f"172.16.0.{i}"
+        assert json_dict["subnet"] == f"192.168.{i}.0/24"
         assert json_dict["digest"]["md5"] == hashlib.md5(data).hexdigest()
         assert json_dict["digest"]["sha1"] == hashlib.sha1(data).hexdigest()
         assert json_dict["digest"]["sha256"] == hashlib.sha256(data).hexdigest()

--- a/tests/test_rdump.py
+++ b/tests/test_rdump.py
@@ -133,7 +133,7 @@ def test_rdump_json(tmp_path):
     writer.close()
 
     # dump records as JSON lines
-    args = ["rdump", str(record_path), "--jsonlines"]
+    args = ["rdump", str(record_path), "-w", "jsonfile://-?descriptors=true"]
     process = subprocess.Popen(args, stdout=subprocess.PIPE)
     stdout, stderr = process.communicate()
 
@@ -189,3 +189,58 @@ def test_rdump_json(tmp_path):
                 assert record.digest.sha1 == sha1
                 assert record.digest.sha256 == sha256
                 assert record.foo == "bar" * i
+
+
+def test_rdump_json_no_descriptors(tmp_path):
+    TestRecord = RecordDescriptor(
+        "test/record",
+        [
+            ("varint", "count"),
+            ("string", "foo"),
+            ("bytes", "data"),
+            ("net.ipaddress", "ip"),
+            ("net.ipnetwork", "subnet"),
+            ("digest", "digest"),
+        ],
+    )
+
+    # generate some test records
+    record_path = tmp_path / "test.records"
+    with RecordWriter(record_path) as writer:
+        for i in range(10):
+            data = str(i).encode()
+            md5 = hashlib.md5(data).hexdigest()
+            sha1 = hashlib.sha1(data).hexdigest()
+            sha256 = hashlib.sha256(data).hexdigest()
+            writer.write(
+                TestRecord(
+                    count=i,
+                    foo="bar" * i,
+                    data=b"\x00\x01\x02\x03--" + data,
+                    ip="172.16.0.{}".format(i),
+                    subnet="192.168.{}.0/24".format(i),
+                    digest=(md5, sha1, sha256),
+                )
+            )
+
+    # dump records as JSON lines
+    args = ["rdump", str(record_path), "--jsonlines"]
+    process = subprocess.Popen(args, stdout=subprocess.PIPE)
+    stdout, stderr = process.communicate()
+
+    assert process.returncode == 0
+    assert stderr is None
+
+    for i, line in enumerate(stdout.splitlines()):
+        json_dict = json.loads(line)
+        assert json_dict
+        assert "_type" not in json_dict
+        assert "_recorddescriptor" not in json_dict
+        assert "_source" in json_dict
+        data = str(i).encode()
+        assert json_dict["data"] == base64.b64encode(b"\x00\x01\x02\x03--" + data).decode()
+        assert json_dict["ip"] == "172.16.0.{}".format(i)
+        assert json_dict["subnet"] == "192.168.{}.0/24".format(i)
+        assert json_dict["digest"]["md5"] == hashlib.md5(data).hexdigest()
+        assert json_dict["digest"]["sha1"] == hashlib.sha1(data).hexdigest()
+        assert json_dict["digest"]["sha256"] == hashlib.sha256(data).hexdigest()


### PR DESCRIPTION
This disables outputting recorddescriptor information in the JSON output when using `--json` or `--jsonlines` as this is rarely what you want as an end user.

It's still possible to output recorddescriptor information if you use `jsonfile://<file>?descriptors=true` as the adapter.

(DIS-1637)