### PR TITLE
DeprecationWarning when using `net.ipv4.Subnet` or `net.ipv4.Address`

### DIFF
--- a/flow/record/fieldtypes/net/ipv4.py
+++ b/flow/record/fieldtypes/net/ipv4.py
@@ -1,5 +1,6 @@
 import struct
 import socket
+import warnings
 
 from flow.record import FieldType
 from flow.record.utils import to_native_str
@@ -39,6 +40,11 @@ class subnet(FieldType):
     _type = "net.ipv4.subnet"
 
     def __init__(self, addr, netmask=None):
+        warnings.warn(
+            "net.ipv4.subnet fieldtype is deprecated, use net.ipnetwork instead",
+            DeprecationWarning,
+            stacklevel=5,
+        )
         if isinstance(addr, type("")):
             addr = to_native_str(addr)
 
@@ -111,6 +117,11 @@ class address(FieldType):
     _type = "net.ipv4.address"
 
     def __init__(self, addr):
+        warnings.warn(
+            "net.ipv4.address fieldtype is deprecated, use net.ipaddress instead",
+            DeprecationWarning,
+            stacklevel=5,
+        )
         self.val = addr_long(addr)
 
     def __eq__(self, b):

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,0 +1,27 @@
+import pytest
+
+from flow.record import RecordDescriptor
+
+
+def test_deprecate_ipv4_address():
+    TestRecord = RecordDescriptor(
+        "test/net/ipv4/Address",
+        [
+            ("net.ipv4.Address", "ip"),
+        ],
+    )
+
+    with pytest.warns(DeprecationWarning, match="net.ipv4.address fieldtype is deprecated, use net.ipaddress instead"):
+        TestRecord("127.0.0.1")
+
+
+def test_deprecate_ipv4_subnet():
+    TestRecord = RecordDescriptor(
+        "test/net/ipv4/Subnet",
+        [
+            ("net.ipv4.Subnet", "network"),
+        ],
+    )
+
+    with pytest.warns(DeprecationWarning, match="net.ipv4.subnet fieldtype is deprecated, use net.ipnetwork instead"):
+        TestRecord("192.168.0.0/24")

--- a/tests/test_fieldtypes.py
+++ b/tests/test_fieldtypes.py
@@ -81,18 +81,20 @@ def test_net_ipv4_address():
         ],
     )
 
-    TestRecord("1.1.1.1")
-    TestRecord("0.0.0.0")
-    TestRecord("192.168.0.1")
-    TestRecord("255.255.255.255")
+    with pytest.deprecated_call():
+        TestRecord("1.1.1.1")
+        TestRecord("0.0.0.0")
+        TestRecord("192.168.0.1")
+        TestRecord("255.255.255.255")
 
-    r = TestRecord("127.0.0.1")
+        r = TestRecord("127.0.0.1")
 
     assert isinstance(r.ip, net.ipv4.Address)
 
     for invalid in ["1.1.1.256", "192.168.0.1/24", "a.b.c.d"]:
         with pytest.raises(Exception) as excinfo:
-            TestRecord(invalid)
+            with pytest.deprecated_call():
+                TestRecord(invalid)
         excinfo.match(r".*illegal IP address string.*")
 
     r = TestRecord()
@@ -107,7 +109,8 @@ def test_net_ipv4_subnet():
         ],
     )
 
-    r = TestRecord("1.1.1.0/24")
+    with pytest.deprecated_call():
+        r = TestRecord("1.1.1.0/24")
     assert str(r.subnet) == "1.1.1.0/24"
 
     assert "1.1.1.1" in r.subnet
@@ -116,24 +119,28 @@ def test_net_ipv4_subnet():
     assert "1.1.2.1" not in r.subnet
     # assert "1.1.1.1/32" not in r.subnet
 
-    r = TestRecord("0.0.0.0")
-    r = TestRecord("192.168.0.1")
-    r = TestRecord("255.255.255.255")
+    with pytest.deprecated_call():
+        r = TestRecord("0.0.0.0")
+        r = TestRecord("192.168.0.1")
+        r = TestRecord("255.255.255.255")
 
-    r = TestRecord("127.0.0.1")
+        r = TestRecord("127.0.0.1")
 
     for invalid in ["a.b.c.d", "foo", "bar", ""]:
         with pytest.raises(Exception) as excinfo:
-            TestRecord(invalid)
+            with pytest.deprecated_call():
+                TestRecord(invalid)
         excinfo.match(r".*illegal IP address string.*")
 
     for invalid in [1, 1.0, sum, dict(), list(), True]:
         with pytest.raises(TypeError) as excinfo:
-            TestRecord(invalid)
+            with pytest.deprecated_call():
+                TestRecord(invalid)
         excinfo.match(r"Subnet\(\) argument 1 must be string, not .*")
 
     with pytest.raises(ValueError) as excinfo:
-        TestRecord("192.168.0.106/28")
+        with pytest.deprecated_call():
+            TestRecord("192.168.0.106/28")
     excinfo.match(r"Not a valid subnet '192\.168\.0\.106/28', did you mean '192\.168\.0\.96/28' ?")
 
 
@@ -329,7 +336,8 @@ def test_float():
 
     # invalid float
     with pytest.raises(ValueError):
-        r = TestRecord("abc")
+        with pytest.deprecated_call():
+            r = TestRecord("abc")
 
 
 def test_uri_type():

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -336,7 +336,8 @@ def test_multi_grouped_record_serialization(tmp_path):
         ],
     )
 
-    test_rec = TestRecord("1.3.3.7")
+    with pytest.deprecated_call():
+        test_rec = TestRecord("1.3.3.7")
     geo_rec = GeoRecord(country="Netherlands", city="Delft")
 
     grouped_rec = GroupedRecord("grouped/geoip", [test_rec, geo_rec])
@@ -353,15 +354,16 @@ def test_multi_grouped_record_serialization(tmp_path):
     writer.write(record)
     writer.close()
 
-    reader = RecordReader(tmp_path / "out.record")
-    records = list(reader)
-    assert len(records) == 1
-    record = records[0]
-    assert record.ip == "1.3.3.7"
-    assert record.country == "Netherlands"
-    assert record.city == "Delft"
-    assert record.asn == "1337"
-    assert record.isp == "Cyberspace"
+    with pytest.deprecated_call():
+        reader = RecordReader(tmp_path / "out.record")
+        records = list(reader)
+        assert len(records) == 1
+        record = records[0]
+        assert record.ip == "1.3.3.7"
+        assert record.country == "Netherlands"
+        assert record.city == "Delft"
+        assert record.asn == "1337"
+        assert record.isp == "Cyberspace"
 
 
 @pytest.mark.parametrize("PSelector", [Selector, CompiledSelector])

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -214,9 +214,10 @@ def test_selector_function_call_whitelisting():
             ("net.ipv4.Address", "ip"),
         ],
     )
-    rec = IPRecord("192.168.1.1")
-    assert rec in Selector("r.ip in net.ipv4.Subnet('192.168.1.0/24')")
-    assert rec not in Selector("r.non_existing_field in net.ipv4.Subnet('192.168.1.0/24')")
+    with pytest.deprecated_call():
+        rec = IPRecord("192.168.1.1")
+        assert rec in Selector("r.ip in net.ipv4.Subnet('192.168.1.0/24')")
+        assert rec not in Selector("r.non_existing_field in net.ipv4.Subnet('192.168.1.0/24')")
 
     # We call net.ipv4 instead of net.ipv4.Subnet, which should fail
     with pytest.raises(Exception) as excinfo:
@@ -231,14 +232,15 @@ def test_selector_subnet():
             ("net.ipv4.Address", "ip"),
         ],
     )
-    rec = desc("192.168.10.1")
+    with pytest.deprecated_call():
+        rec = desc("192.168.10.1")
 
-    assert rec in Selector("r.ip in net.ipv4.Subnet('192.168.10.1/32')")
-    assert rec in Selector("r.ip in net.ipv4.Subnet('192.168.10.0/24')")
-    assert rec in Selector("r.ip in net.ipv4.Subnet('192.168.0.0/16')")
-    assert rec in Selector("r.ip in net.ipv4.Subnet('192.0.0.0/8')")
-    assert rec in Selector("r.ip in net.ipv4.Subnet('192.168.10.1')")
-    assert rec in Selector("r.ip not in net.ipv4.Subnet('10.0.0.0/8')")
+        assert rec in Selector("r.ip in net.ipv4.Subnet('192.168.10.1/32')")
+        assert rec in Selector("r.ip in net.ipv4.Subnet('192.168.10.0/24')")
+        assert rec in Selector("r.ip in net.ipv4.Subnet('192.168.0.0/16')")
+        assert rec in Selector("r.ip in net.ipv4.Subnet('192.0.0.0/8')")
+        assert rec in Selector("r.ip in net.ipv4.Subnet('192.168.10.1')")
+        assert rec in Selector("r.ip not in net.ipv4.Subnet('10.0.0.0/8')")
 
 
 def test_field_equals():
@@ -388,16 +390,17 @@ def test_selector_typed():
             ("net.ipv4.Address", "ip"),
         ],
     )
-    rec = TestNamespaceRecord("192.168.10.1")
+    with pytest.deprecated_call():
+        rec = TestNamespaceRecord("192.168.10.1")
 
-    # This will only work in "normal" selectors, because we need to override the behaviour
-    # of the __contains__ operator to unwrap the requested values
-    assert rec in Selector("Type.net.ipv4.Address in net.ipv4.Subnet('192.168.10.1/32')")
-    assert rec in Selector("Type.net.ipv4.Address in net.ipv4.Subnet('192.168.10.0/24')")
-    assert rec in Selector("Type.net.ipv4.Address in net.ipv4.Subnet('192.168.0.0/16')")
-    assert rec in Selector("Type.net.ipv4.Address in net.ipv4.Subnet('192.0.0.0/8')")
-    assert rec in Selector("Type.net.ipv4.Address in net.ipv4.Subnet('192.168.10.1')")
-    assert rec in Selector("Type.net.ipv4.Address not in net.ipv4.Subnet('10.0.0.0/8')")
+        # This will only work in "normal" selectors, because we need to override the behaviour
+        # of the __contains__ operator to unwrap the requested values
+        assert rec in Selector("Type.net.ipv4.Address in net.ipv4.Subnet('192.168.10.1/32')")
+        assert rec in Selector("Type.net.ipv4.Address in net.ipv4.Subnet('192.168.10.0/24')")
+        assert rec in Selector("Type.net.ipv4.Address in net.ipv4.Subnet('192.168.0.0/16')")
+        assert rec in Selector("Type.net.ipv4.Address in net.ipv4.Subnet('192.0.0.0/8')")
+        assert rec in Selector("Type.net.ipv4.Address in net.ipv4.Subnet('192.168.10.1')")
+        assert rec in Selector("Type.net.ipv4.Address not in net.ipv4.Subnet('10.0.0.0/8')")
 
     with pytest.raises(InvalidOperation):
         assert rec in Selector("Type.uri.filename.__class__ == 'invalid'")


### PR DESCRIPTION
The fieldtypes `net.ipv4.Address` and `net.ipv4.Subnet` are deprecated, a warning is given to use `net.ipaddress` and `net.ipnetwork` instead.

(DIS-1638)