### PR TITLE
Fixed bytes output when using LineAdapter

### DIFF
--- a/flow/record/fieldtypes/__init__.py
+++ b/flow/record/fieldtypes/__init__.py
@@ -219,9 +219,9 @@ class bytes(bytes_type, FieldType):
             return self.hex()
         elif spec in ("HEX", "X"):
             return self.hex().upper()
-        elif spec in ("#x"):
+        elif spec == "#x":
             return "0x" + self.hex()
-        elif spec in ("#X"):
+        elif spec == "#X":
             return "0x" + self.hex().upper()
         return bytes_type.__format__(self, spec)
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -419,5 +419,20 @@ def test_grouped_replace():
     excinfo.match(".*Got unexpected field names:.*non_existing_field.*")
 
 
+def test_bytes_line_adapter(capsys):
+    TestRecord = RecordDescriptor(
+        "test/bytes_hex",
+        [
+            ("bytes", "data"),
+        ],
+    )
+
+    with RecordWriter("line://") as writer:
+        writer.write(TestRecord(b"hello world"))
+
+    captured = capsys.readouterr()
+    assert "data = b'hello world'" in captured.out
+
+
 if __name__ == "__main__":
     __import__("standalone_test").main(globals())


### PR DESCRIPTION
Bug was introduced in 083e3b25ff2b2e4985dafe795fbda7e9fb803d9f
Due to incorrect `in` operation, bytes would be printed as hex strings.