### PR TITLE
Fix flow.record datetime for timezones

### DIFF
--- a/flow/record/fieldtypes/__init__.py
+++ b/flow/record/fieldtypes/__init__.py
@@ -4,7 +4,7 @@ import os
 import pathlib
 import re
 from binascii import a2b_hex, b2a_hex
-from datetime import datetime as _dt, timedelta
+from datetime import datetime as _dt, timezone
 from posixpath import basename, dirname
 from typing import Tuple
 
@@ -261,7 +261,11 @@ class datetime(_dt, FieldType):
         return _dt.__new__(cls, *args, **kwargs)
 
     def __eq__(self, other):
-        return self - other == timedelta(0)
+        # Avoid TypeError: can't compare offset-naive and offset-aware datetimes
+        # naive datetimes are treated as UTC in flow.record instead of local time
+        ts1 = self.timestamp() if self.tzinfo else self.replace(tzinfo=timezone.utc).timestamp()
+        ts2 = other.timestamp() if other.tzinfo else other.replace(tzinfo=timezone.utc).timestamp()
+        return ts1 == ts2
 
     def _pack(self):
         return self

--- a/tests/test_multi_timestamp.py
+++ b/tests/test_multi_timestamp.py
@@ -84,3 +84,30 @@ def test_multi_timestamp_ts_fieldname():
     assert len(ts_records) == 1
     assert ts_records[0].ts == test_record.ts
     assert ts_records[0].ts_description == "ts"
+
+
+def test_multi_timestamp_timezone():
+    TestRecord = RecordDescriptor(
+        "test/record",
+        [
+            ("datetime", "ts"),
+            ("string", "data"),
+        ],
+    )
+
+    correct_ts = datetime.datetime(2023, 12, 31, 13, 37, 1, 123456, tzinfo=datetime.timezone.utc)
+
+    ts_notations = [
+        correct_ts,
+        "2023-12-31T13:37:01.123456Z",
+    ]
+
+    for i, ts_notation in enumerate(ts_notations):
+        test_record = TestRecord(
+            ts=ts_notation,
+            data=f"record with timezone ({str(i)})",
+        )
+        ts_records = list(iter_timestamped_records(test_record))
+        assert len(ts_records) == 1
+        assert ts_records[0].ts == correct_ts
+        assert ts_records[0].ts_description == "ts"


### PR DESCRIPTION
Add support for parsing datetime strings with `%z` timezone information.