### PR TITLE
Use newline='' for CsvfileWriter

### DIFF
--- a/flow/record/adapter/csvfile.py
+++ b/flow/record/adapter/csvfile.py
@@ -9,7 +9,7 @@ from flow.record.adapter import AbstractWriter
 __usage__ = """
 Comma-separated values (CSV) adapter
 ---
-Write usage: rdump -w csvfile://[PATH]&lineterminator=[TERMINATOR]
+Write usage: rdump -w csvfile://[PATH]?lineterminator=[TERMINATOR]
 Read usage: rdump csvfile://[PATH]
 [PATH]: path to file. Leave empty or "-" to output to stdout
 [TERMINATOR]: line terminator, default is \\r\\n

--- a/flow/record/adapter/csvfile.py
+++ b/flow/record/adapter/csvfile.py
@@ -3,27 +3,30 @@ from __future__ import absolute_import
 import sys
 from csv import DictWriter
 
-from flow.record import open_path
 from flow.record.utils import is_stdout
 from flow.record.adapter import AbstractWriter
 
 __usage__ = """
 Comma-separated values (CSV) adapter
 ---
-Write usage: rdump -w csvfile://[PATH]
+Write usage: rdump -w csvfile://[PATH]&lineterminator=[TERMINATOR]
 Read usage: rdump csvfile://[PATH]
 [PATH]: path to file. Leave empty or "-" to output to stdout
+[TERMINATOR]: line terminator, default is \\r\\n
 """
 
 
 class CsvfileWriter(AbstractWriter):
     fp = None
 
-    def __init__(self, path, fields=None, exclude=None, **kwargs):
-        mode = "w"
-        if sys.version_info[0] < 3:
-            mode = "wb"
-        self.fp = open_path(path, mode)
+    def __init__(self, path, fields=None, exclude=None, lineterminator=None, **kwargs):
+        if path in (None, "", "-"):
+            self.fp = sys.stdout
+        else:
+            self.fp = open(path, "w", newline="")
+        self.lineterminator = lineterminator or "\r\n"
+        for r, n in ((r"\r", "\r"), (r"\n", "\n"), (r"\t", "\t")):
+            self.lineterminator = self.lineterminator.replace(r, n)
         self.desc = None
         self.writer = None
         self.fields = fields
@@ -37,7 +40,7 @@ class CsvfileWriter(AbstractWriter):
         rdict = r._asdict(fields=self.fields, exclude=self.exclude)
         if not self.desc or self.desc != r._desc:
             self.desc = r._desc
-            self.writer = DictWriter(self.fp, rdict)
+            self.writer = DictWriter(self.fp, rdict, lineterminator=self.lineterminator)
             self.writer.writeheader()
         self.writer.writerow(rdict)
 

--- a/tests/test_record_adapter.py
+++ b/tests/test_record_adapter.py
@@ -403,3 +403,35 @@ def test_recordstream_header_stdout(capsysbinary):
     writer.close()
     out, err = capsysbinary.readouterr()
     assert out == b"\x00\x00\x00\x0f\xc4\rRECORDSTREAM\n"
+
+
+def test_csv_adapter_lineterminator(capsysbinary):
+    TestRecord = RecordDescriptor(
+        "test/record",
+        [
+            ("uint32", "count"),
+            ("string", "foo"),
+            ("string", "bar"),
+        ],
+    )
+
+    with RecordWriter(r"csvfile://?lineterminator=\r\n&exclude=_source,_classification,_generated,_version") as writer:
+        for i in range(3):
+            rec = TestRecord(count=i, foo="hello", bar="world")
+            writer.write(rec)
+    out, _ = capsysbinary.readouterr()
+    assert out == b'count,foo,bar\r\n0,hello,world\r\n1,hello,world\r\n2,hello,world\r\n'
+
+    with RecordWriter(r"csvfile://?lineterminator=\n&exclude=_source,_classification,_generated,_version") as writer:
+        for i in range(3):
+            rec = TestRecord(count=i, foo="hello", bar="world")
+            writer.write(rec)
+    out, _ = capsysbinary.readouterr()
+    assert out == b'count,foo,bar\n0,hello,world\n1,hello,world\n2,hello,world\n'
+
+    with RecordWriter(r"csvfile://?lineterminator=@&exclude=_source,_classification,_generated,_version") as writer:
+        for i in range(3):
+            rec = TestRecord(count=i, foo="hello", bar="world")
+            writer.write(rec)
+    out, _ = capsysbinary.readouterr()
+    assert out == b'count,foo,bar@0,hello,world@1,hello,world@2,hello,world@'

--- a/tests/test_record_adapter.py
+++ b/tests/test_record_adapter.py
@@ -420,18 +420,18 @@ def test_csv_adapter_lineterminator(capsysbinary):
             rec = TestRecord(count=i, foo="hello", bar="world")
             writer.write(rec)
     out, _ = capsysbinary.readouterr()
-    assert out == b'count,foo,bar\r\n0,hello,world\r\n1,hello,world\r\n2,hello,world\r\n'
+    assert out == b"count,foo,bar\r\n0,hello,world\r\n1,hello,world\r\n2,hello,world\r\n"
 
     with RecordWriter(r"csvfile://?lineterminator=\n&exclude=_source,_classification,_generated,_version") as writer:
         for i in range(3):
             rec = TestRecord(count=i, foo="hello", bar="world")
             writer.write(rec)
     out, _ = capsysbinary.readouterr()
-    assert out == b'count,foo,bar\n0,hello,world\n1,hello,world\n2,hello,world\n'
+    assert out == b"count,foo,bar\n0,hello,world\n1,hello,world\n2,hello,world\n"
 
     with RecordWriter(r"csvfile://?lineterminator=@&exclude=_source,_classification,_generated,_version") as writer:
         for i in range(3):
             rec = TestRecord(count=i, foo="hello", bar="world")
             writer.write(rec)
     out, _ = capsysbinary.readouterr()
-    assert out == b'count,foo,bar@0,hello,world@1,hello,world@2,hello,world@'
+    assert out == b"count,foo,bar@0,hello,world@1,hello,world@2,hello,world@"


### PR DESCRIPTION
Fixes #42

This commit also adds the `lineterminator` option to the csvfile adapter
It defaults to `\r\n`, which is also the Python default.

If you want to output csv files with only `\n`, you can do so using:

    csvfile://?lineterminator=\n