### PR TITLE
Fix exception when using `datetime` as a RecordDescriptor fieldname

### DIFF
--- a/flow/record/base.py
+++ b/flow/record/base.py
@@ -65,6 +65,8 @@ RECORD_CLASS_TEMPLATE = """
 from datetime import datetime
 from itertools import zip_longest
 
+_utcnow = datetime.utcnow
+
 class {name}(Record):
     _desc = desc
     _field_types = {field_types}
@@ -409,7 +411,7 @@ class RecordDescriptor:
                 ).format(field=field.name, default=default)
             unpack_code += "\t\t)"
 
-        init_code += "\t\t__self._generated = _generated or datetime.utcnow()\n\t\t__self._version = RECORD_VERSION"
+        init_code += "\t\t__self._generated = _generated or _utcnow()\n\t\t__self._version = RECORD_VERSION"
         # Store the fieldtypes so we can enforce them in __setattr__()
         field_types = "{\n"
         for field in all_fields:

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -595,5 +595,15 @@ def test_record_adapter_windows_path(tmp_path):
         m.assert_called_once_with(r"c:\users\user\test.records", "wb")
 
 
+def test_datetime_as_fieldname():
+    TestRecord = RecordDescriptor(
+        "test/record",
+        [
+            ("string", "datetime"),
+        ],
+    )
+    TestRecord()
+
+
 if __name__ == "__main__":
     __import__("standalone_test").main(globals())


### PR DESCRIPTION
Before this the `datetime` fieldname/keyword argument would overwrite the imported `datetime` module in RECORD_CLASS_TEMPLATE and would raise:

> AttributeError: 'NoneType' object has no attribute 'utcnow'