### PR TITLE
Allow serialization and deserialization of `surrogateescape` strings

### DIFF
--- a/flow/record/packer.py
+++ b/flow/record/packer.py
@@ -8,7 +8,7 @@ from .base import Record, FieldType, RecordDescriptor, GroupedRecord, RESERVED_F
 from .utils import EventHandler, to_str
 
 # Override defaults for msgpack packb/unpackb
-packb = functools.partial(msgpack.packb, use_bin_type=True)
+packb = functools.partial(msgpack.packb, use_bin_type=True, unicode_errors="backslashreplace")
 unpackb = functools.partial(msgpack.unpackb, raw=False)
 
 RECORD_PACK_EXT_TYPE = 0xE

--- a/flow/record/packer.py
+++ b/flow/record/packer.py
@@ -8,8 +8,8 @@ from .base import Record, FieldType, RecordDescriptor, GroupedRecord, RESERVED_F
 from .utils import EventHandler, to_str
 
 # Override defaults for msgpack packb/unpackb
-packb = functools.partial(msgpack.packb, use_bin_type=True, unicode_errors="backslashreplace")
-unpackb = functools.partial(msgpack.unpackb, raw=False)
+packb = functools.partial(msgpack.packb, use_bin_type=True, unicode_errors="surrogateescape")
+unpackb = functools.partial(msgpack.unpackb, raw=False, unicode_errors="surrogateescape")
 
 RECORD_PACK_EXT_TYPE = 0xE
 


### PR DESCRIPTION
Make flow record more robust against invalid UTF-8 byte sequences like UTF-16 surrogate-like sequences

(DIS-1735)