### PR TITLE
Add `--split` option to `rdump`

### DIFF
--- a/flow/record/adapter/split.py
+++ b/flow/record/adapter/split.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+
+from urllib.parse import urlparse
+
+from flow.record.adapter import AbstractWriter
+from flow.record.base import RecordWriter
+
+DEFAULT_RECORD_COUNT = 1000
+DEFAULT_SUFFIX_LENGTH = 2
+
+__usage__ = f"""
+Record split adapter, splits records into multiple destination files (writer only)
+---
+Write usage: rdump -w split://[PATH]?count=[COUNT]&suffix-length=[SUFFIX-LENGTH]
+[PATH]: output path or uri
+[COUNT]: maximum record count per file (default: {DEFAULT_RECORD_COUNT})
+[SUFFIX-LENGTH]: length of suffix (default: {DEFAULT_SUFFIX_LENGTH})
+"""
+
+
+class SplitWriter(AbstractWriter):
+    writer = None
+
+    def __init__(self, path, **kwargs):
+        self.path = str(path)
+        self.kwargs = kwargs
+
+        self.written = 0
+        self.count = int(kwargs.get("count", DEFAULT_RECORD_COUNT))
+        self.suffix_length = int(kwargs.get("suffix-length", DEFAULT_SUFFIX_LENGTH))
+        self.file_count = 0
+
+        parsed = urlparse(self.path)
+        self.is_stdout = parsed.netloc in ("", "-") and parsed.path == ""
+
+        self.writer = RecordWriter(self._next_path(), **self.kwargs)
+
+    def _next_path(self):
+        if self.is_stdout:
+            return self.path
+
+        path = self.path
+        scheme = ""
+        sep = ""
+        if "://" in path:
+            scheme, sep, path = path.partition("://")
+
+        suffix = f"{self.file_count}".rjust(self.suffix_length, "0")
+        path = Path(path)
+        path = path.with_suffix(f".{suffix}{path.suffix}")
+
+        self.file_count += 1
+        return scheme + sep + str(path)
+
+    def write(self, r):
+        self.writer.write(r)
+
+        if self.is_stdout:
+            return
+
+        self.written += 1
+        if self.written >= self.count:
+            self.flush()
+            self.close()
+            self.written = 0
+            self.writer = RecordWriter(self._next_path(), **self.kwargs)
+
+    def flush(self):
+        if self.writer:
+            self.writer.flush()
+
+    def close(self):
+        if self.writer:
+            self.writer.close()
+        self.writer = None

--- a/flow/record/adapter/split.py
+++ b/flow/record/adapter/split.py
@@ -45,7 +45,7 @@ class SplitWriter(AbstractWriter):
         if "://" in path:
             scheme, sep, path = path.partition("://")
 
-        suffix = f"{self.file_count}".rjust(self.suffix_length, "0")
+        suffix = str(self.file_count).rjust(self.suffix_length, "0")
         path = Path(path)
         path = path.with_suffix(f".{suffix}{path.suffix}")
 

--- a/flow/record/base.py
+++ b/flow/record/base.py
@@ -671,7 +671,7 @@ def open_path(path, mode, clobber=True):
     return fp
 
 
-def RecordAdapter(url, out, selector=None, clobber=True):
+def RecordAdapter(url, out, selector=None, clobber=True, **kwargs):
     url = str(url or "")
 
     # Guess adapter based on extension
@@ -694,6 +694,7 @@ def RecordAdapter(url, out, selector=None, clobber=True):
 
     cls = getattr(mod, clsname)
     arg_dict = dict(parse_qsl(p.query))
+    arg_dict.update(kwargs)
     cls_url = p.netloc + p.path
     if sub_adapter:
         cls_url = sub_adapter + "://" + cls_url
@@ -708,12 +709,12 @@ def RecordAdapter(url, out, selector=None, clobber=True):
     return cls(cls_url, **arg_dict)
 
 
-def RecordReader(url=None, selector=None):
-    return RecordAdapter(url, False, selector=selector)
+def RecordReader(url=None, selector=None, **kwargs):
+    return RecordAdapter(url, False, selector=selector, **kwargs)
 
 
-def RecordWriter(url=None, clobber=True):
-    return RecordAdapter(url, True, clobber=clobber)
+def RecordWriter(url=None, clobber=True, **kwargs):
+    return RecordAdapter(url, True, clobber=clobber, **kwargs)
 
 
 def stream(src, dst):

--- a/flow/record/base.py
+++ b/flow/record/base.py
@@ -678,6 +678,7 @@ def RecordAdapter(url, out, selector=None, clobber=True, **kwargs):
     ext_to_adapter = {
         ".avro": "avro",
         ".json": "jsonfile",
+        ".jsonl": "jsonfile",
     }
     _, ext = os.path.splitext(url)
 

--- a/flow/record/tools/rdump.py
+++ b/flow/record/tools/rdump.py
@@ -101,7 +101,11 @@ def main(argv=None):
         "--split", metavar="COUNT", default=None, type=int, help="Write record files smaller than COUNT records"
     )
     output.add_argument(
-        "--suffix-length", metavar="LEN", default=2, type=int, help="Generate suffixes of length LEN for splitted output files"
+        "--suffix-length",
+        metavar="LEN",
+        default=2,
+        type=int,
+        help="Generate suffixes of length LEN for splitted output files",
     )
     output.add_argument("--multi-timestamp", action="store_true", help="Create records for datetime fields")
 

--- a/tests/test_rdump.py
+++ b/tests/test_rdump.py
@@ -313,6 +313,7 @@ def test_rdump_list_adapters():
         "output.records.gz",
         "output.records.bz2",
         "output.records.json",
+        "output.records.jsonl",
     ],
 )
 def test_rdump_split(tmp_path, filename):
@@ -405,3 +406,10 @@ def test_rdump_split_using_uri(tmp_path, scheme, first_line, capsysbinary):
         assert path.exists()
         with open(path, "rb") as f:
             assert first_line in next(f)
+
+
+def test_rdump_split_without_writer(capsysbinary):
+    with pytest.raises(SystemExit):
+        rdump.main(["--split=10"])
+    captured = capsysbinary.readouterr()
+    assert b"error: --split only makes sense in combination with -w/--writer" in captured.err


### PR DESCRIPTION
This implements #46, which allows you to split records over multiple smaller output files.

Example usage:

```shell
$ target-query -f mft -t MSEDGEWIN10.tar --limit 10 | rdump --split 6 -w mft.json
$ wc -l mft*.json
       8 mft.00.json
       6 mft.01.json
      14 total

$ rdump mft.00.json -l | grep Processed
Processed 6 records

$ rdump mft.01.json -l | grep Processed
Processed 4 records
```