### PR TITLE
Refactor and cleanup RecordDescriptor class

### DIFF
--- a/flow/record/base.py
+++ b/flow/record/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import collections
 import functools
 import gzip
@@ -570,7 +572,7 @@ class RecordDescriptor:
         """
         return self.init_from_dict(record._asdict(), raise_unknown=raise_unknown)
 
-    def extend(self, fields: Sequence[Tuple[str, str]]) -> "RecordDescriptor":
+    def extend(self, fields: Sequence[Tuple[str, str]]) -> RecordDescriptor:
         """Returns a new RecordDescriptor with the extended fields
 
         Returns:
@@ -614,7 +616,7 @@ class RecordDescriptor:
     def __hash__(self) -> int:
         return hash((self.name, self.get_field_tuples()))
 
-    def __eq__(self, other: "RecordDescriptor") -> bool:
+    def __eq__(self, other: RecordDescriptor) -> bool:
         if isinstance(other, RecordDescriptor):
             return self.name == other.name and self.get_field_tuples() == other.get_field_tuples()
         return NotImplemented
@@ -649,7 +651,7 @@ class RecordDescriptor:
         return (self.name, self._field_tuples)
 
     @staticmethod
-    def _unpack(name, fields: Tuple[Tuple[str, str]]) -> "RecordDescriptor":
+    def _unpack(name, fields: Tuple[Tuple[str, str]]) -> RecordDescriptor:
         return RecordDescriptor(name, fields)
 
 

--- a/flow/record/base.py
+++ b/flow/record/base.py
@@ -434,6 +434,8 @@ def _generate_record_class(name: str, fields: Tuple[Tuple[str, str]]) -> type:
 
 
 class RecordDescriptor:
+    """Record Descriptor class for defining a Record type and its fields."""
+
     name: str = None
     recordType: type = None
     _desc_hash: int = None
@@ -441,7 +443,7 @@ class RecordDescriptor:
     _all_fields: Mapping[str, RecordField] = None
     _field_tuples: Sequence[Tuple[str, str]] = None
 
-    def __init__(self, name: str, fields: Optional[Sequence[Tuple[str, str]]] = None) -> None:
+    def __init__(self, name: str, fields: Optional[Sequence[Tuple[str, str]]] = None):
         if not name:
             raise RecordDescriptorError("Record name is required")
 

--- a/flow/record/base.py
+++ b/flow/record/base.py
@@ -788,6 +788,7 @@ def stream(src, dst):
     dst.flush()
 
 
+@functools.lru_cache()
 def fieldtype(clspath: str) -> FieldType:
     """Return the FieldType class for the given field type class path.
 

--- a/flow/record/base.py
+++ b/flow/record/base.py
@@ -8,7 +8,6 @@ import keyword
 import logging
 import os
 import re
-import struct
 import sys
 import warnings
 from datetime import datetime
@@ -38,7 +37,6 @@ except ImportError:
     HAS_ZSTD = False
 
 from collections import OrderedDict
-from operator import itemgetter as _itemgetter
 
 from .utils import to_native_str, to_str
 from .whitelist import WHITELIST, WHITELIST_TREE

--- a/flow/record/base.py
+++ b/flow/record/base.py
@@ -487,7 +487,7 @@ class RecordDescriptor:
     @property
     def fields(self) -> Mapping[str, RecordField]:
         """
-        Get fields mapping. eg:
+        Get fields mapping (without required fields). eg:
 
         {
             "foo": RecordField("foo", "string"),
@@ -509,6 +509,10 @@ class RecordDescriptor:
             "ts": RecordField("ts", "datetime"),
             "foo": RecordField("foo", "string"),
             "bar": RecordField("bar", "varint"),
+            "_source": RecordField("_source", "string"),
+            "_classification": RecordField("_classification", "datetime"),
+            "_generated": RecordField("_generated", "datetime"),
+            "_version": RecordField("_version", "vaeint"),
         }
 
         Returns:

--- a/flow/record/base.py
+++ b/flow/record/base.py
@@ -318,7 +318,7 @@ class RecordField:
     typename = None
     type = None
 
-    def __init__(self, name: str, typename: str) -> None:
+    def __init__(self, name: str, typename: str):
         if not is_valid_field_name(name, check_reserved=False):
             raise RecordDescriptorError("Invalid field name: {}".format(name))
 

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,6 +1,7 @@
 import pytest
 
 from flow.record import RecordDescriptor
+from flow.record.base import parse_def
 
 
 def test_deprecate_ipv4_address():
@@ -25,3 +26,35 @@ def test_deprecate_ipv4_subnet():
 
     with pytest.warns(DeprecationWarning, match="net.ipv4.subnet fieldtype is deprecated, use net.ipnetwork instead"):
         TestRecord("192.168.0.0/24")
+
+
+def test_deprecate_parse_def():
+    with pytest.deprecated_call():
+        parse_def("test/record")
+
+
+def test_deprecate_recorddescriptor_init():
+    # Test deprecated RecordDescriptor init with string def
+    with pytest.deprecated_call():
+        TestRecord = RecordDescriptor("test/record", None)
+    assert TestRecord.name == "test/record"
+
+    # Test deprecated RecordDescriptor init with string def and some fields
+    with pytest.deprecated_call():
+        TestRecord = RecordDescriptor(
+            """test/record
+            string foo
+            """
+        )
+    assert TestRecord(foo="bar").foo == "bar"
+
+    TestRecord = RecordDescriptor(
+        "test/record",
+        [
+            ("string", "foo"),
+        ],
+    )
+    # Test deprecated RecordDescriptor init with another RecordDescriptor
+    with pytest.deprecated_call():
+        TestRecord2 = RecordDescriptor("test/init_other_descriptor", TestRecord)
+    assert TestRecord2(foo="bar").foo == "bar"

--- a/tests/test_fieldtypes.py
+++ b/tests/test_fieldtypes.py
@@ -7,12 +7,15 @@ import pathlib
 
 import pytest
 
-from flow.record import RecordDescriptor, RecordReader, RecordWriter
-from flow.record.fieldtypes import net
-from flow.record.fieldtypes import uri
-from flow.record.fieldtypes import fieldtype_for_value
-from flow.record.fieldtypes import PATH_POSIX, PATH_WINDOWS
 import flow.record.fieldtypes
+from flow.record import RecordDescriptor, RecordReader, RecordWriter
+from flow.record.fieldtypes import (
+    PATH_POSIX,
+    PATH_WINDOWS,
+    fieldtype_for_value,
+    net,
+    uri,
+)
 
 INT64_MAX = (1 << 63) - 1
 INT32_MAX = (1 << 31) - 1

--- a/tests/test_record_descriptor.py
+++ b/tests/test_record_descriptor.py
@@ -1,11 +1,10 @@
-import struct
 import hashlib
-
-from flow.record import RecordDescriptor
-from flow.record import RecordField
-from flow.record.exceptions import RecordDescriptorError
+import struct
 
 import pytest
+
+from flow.record import RecordDescriptor, RecordField
+from flow.record.exceptions import RecordDescriptorError
 
 
 def test_record_descriptor():
@@ -46,7 +45,8 @@ def test_record_descriptor_clone():
     )
 
     # Clone record descriptor
-    OtherRecord = RecordDescriptor("other/record", TestRecord)
+    with pytest.deprecated_call():
+        OtherRecord = RecordDescriptor("other/record", TestRecord)
 
     assert TestRecord.name == "test/record"
     assert OtherRecord.name == "other/record"
@@ -82,6 +82,7 @@ def test_record_descriptor_hash_cache():
             ("string", "query"),
         ],
     )
+    assert TestRecord1.identifier == ("test/record", 2149661789)
     info = RecordDescriptor.calc_descriptor_hash.cache_info()
 
     # Create same descriptor, check cache hit increase
@@ -92,6 +93,7 @@ def test_record_descriptor_hash_cache():
             ("string", "query"),
         ],
     )
+    assert TestRecord2.identifier == ("test/record", 2149661789)
     info2 = RecordDescriptor.calc_descriptor_hash.cache_info()
     assert info2.hits == info.hits + 1
     assert info.misses == info2.misses
@@ -106,6 +108,7 @@ def test_record_descriptor_hash_cache():
             ("boolean", "test"),
         ],
     )
+    assert TestRecord3.identifier == ("test/record", 1878143470)
     info3 = RecordDescriptor.calc_descriptor_hash.cache_info()
     assert info2.hits == info.hits + 1
     assert info3.misses == info.misses + 1

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -54,14 +54,6 @@ def test_datetime_serialization():
 def test_long_int_serialization():
     packer = RecordPacker()
 
-    desc = """
-    test/long_types
-    varint long_type;
-    varint int_type;
-    varint long_type_neg;
-    varint int_type_neg;
-    varint max_int_as_long;
-    """
     long_types = RecordDescriptor(
         "test/long_types",
         [

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,33 +1,32 @@
-import pytest
 import codecs
-import os
 import datetime
-import sys
-import pathlib
 import json
+import os
+import pathlib
 import subprocess
-
-from unittest.mock import patch, mock_open
+import sys
+from unittest.mock import mock_open, patch
 
 import msgpack
+import pytest
 
 from flow.record import (
-    base,
-    whitelist,
-    fieldtypes,
-    Record,
+    RECORD_VERSION,
     GroupedRecord,
+    Record,
     RecordDescriptor,
     RecordPacker,
-    RECORD_VERSION,
     RecordReader,
     RecordWriter,
+    base,
+    fieldtypes,
+    whitelist,
 )
-from flow.record.base import is_valid_field_name, fieldtype
+from flow.record.base import _generate_record_class, fieldtype, is_valid_field_name
 from flow.record.packer import RECORD_PACK_EXT_TYPE, RECORD_PACK_TYPE_RECORD
-from flow.record.selector import Selector, CompiledSelector
-from flow.record.utils import is_stdout
+from flow.record.selector import CompiledSelector, Selector
 from flow.record.tools import rdump
+from flow.record.utils import is_stdout
 
 
 def test_datetime_serialization():
@@ -38,11 +37,12 @@ def test_datetime_serialization():
     for tz in ["UTC", "Europe/Amsterdam"]:
         os.environ["TZ"] = tz
 
-        desc = """
-        test/datetime
-        datetime datetime;
-        """
-        descriptor = RecordDescriptor(desc)
+        descriptor = RecordDescriptor(
+            "test/datetime",
+            [
+                ("datetime", "datetime"),
+            ],
+        )
 
         record = descriptor.recordType(datetime=now)
         data = packer.pack(record)
@@ -62,7 +62,16 @@ def test_long_int_serialization():
     varint int_type_neg;
     varint max_int_as_long;
     """
-    long_types = RecordDescriptor(desc)
+    long_types = RecordDescriptor(
+        "test/long_types",
+        [
+            ("varint", "long_type"),
+            ("varint", "int_type"),
+            ("varint", "long_type_neg"),
+            ("varint", "int_type_neg"),
+            ("varint", "max_int_as_long"),
+        ],
+    )
 
     l = 1239812398217398127398217389217389217398271398217321  # noqa: E741
     i = 888888
@@ -84,11 +93,12 @@ def test_long_int_serialization():
 def test_unicode_serialization():
     packer = RecordPacker()
 
-    desc = """
-    test/unicode
-    string text;
-    """
-    descriptor = RecordDescriptor(desc)
+    descriptor = RecordDescriptor(
+        "test/unicode",
+        [
+            ("string", "text"),
+        ],
+    )
 
     puny_domains = [b"xn--s7y.co", b"xn--80ak6aa92e.com", b"xn--pple-43d.com"]
 
@@ -243,6 +253,8 @@ def test_reserved_field_count_regression():
     base.RESERVED_FIELDS["_extra"] = "varint"
     base.RESERVED_FIELDS["_version"] = "varint"
 
+    RecordDescriptor.get_required_fields.cache_clear()
+    _generate_record_class.cache_clear()
     TestRecordExtra = RecordDescriptor(
         "test/record",
         [
@@ -252,6 +264,8 @@ def test_reserved_field_count_regression():
 
     del base.RESERVED_FIELDS["_extra"]
 
+    RecordDescriptor.get_required_fields.cache_clear()
+    _generate_record_class.cache_clear()
     TestRecordBase = RecordDescriptor(
         "test/record",
         [

--- a/tests/test_splunk_adapter.py
+++ b/tests/test_splunk_adapter.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
-from flow.record import RecordDescriptor
 import flow.record.adapter.splunk
+from flow.record import RecordDescriptor
 from flow.record.adapter.splunk import splunkify
 
 
@@ -45,9 +45,7 @@ def test_splunkify_rdtag_field():
         "RESERVED_SPLUNK_FIELDS",
         set(),
     ):
-        test_record_descriptor = RecordDescriptor(
-            "test/record",
-        )
+        test_record_descriptor = RecordDescriptor("test/record", [])
 
         test_record = test_record_descriptor()
 


### PR DESCRIPTION
This commit adds the following improvements:

 * Move Record code generation to `_generate_record_class` which is also cached
 * Add Deprecation warnings to old style RecordDescriptor initialization methods
 * Added type hints and doc strings to RecordDescriptor class
 * RecordDescriptor.identifier is now a property to reduce hash calculation