### PR TITLE
Add UTC timezone when converting timestamps

### DIFF
--- a/flow/record/fieldtypes/__init__.py
+++ b/flow/record/fieldtypes/__init__.py
@@ -244,7 +244,9 @@ class datetime(_dt, FieldType):
                 else:
                     return cls.fromisoformat(arg)
             elif isinstance(arg, (int, float_type)):
-                return cls.utcfromtimestamp(arg)
+                # When we receive integers and floats we expect
+                # them to be epoch timestamps which are UTC by definition.
+                return cls.fromtimestamp(arg, tz=timezone.utc)
             elif isinstance(arg, (_dt,)):
                 return _dt.__new__(
                     cls,

--- a/tests/test_fieldtypes.py
+++ b/tests/test_fieldtypes.py
@@ -435,6 +435,8 @@ def test_datetime():
         ("2023-01-01T12:00:00+01:00", datetime.datetime(2023, 1, 1, 11, 0, 0, tzinfo=datetime.timezone.utc)),
         (datetime.datetime(2023, 1, 1, tzinfo=datetime.timezone.utc), datetime.datetime(2023, 1, 1)),
         (0, datetime.datetime(1970, 1, 1, 0, 0)),
+        (1235813213, datetime.datetime(2009, 2, 28, 9, 26, 53, tzinfo=datetime.timezone.utc)),
+        (1235813213.455891, datetime.datetime(2009, 2, 28, 9, 26, 53, 455891, tzinfo=datetime.timezone.utc)),
     ],
 )
 def test_datetime_formats(tmp_path, value, expected_dt):


### PR DESCRIPTION
This PR changes `datetime` fieldtype behaviour when dealing with input integers and floats.