### PR TITLE
Always write Avro header

### DIFF
--- a/flow/record/adapter/avro.py
+++ b/flow/record/adapter/avro.py
@@ -94,7 +94,7 @@ class AvroReader(AbstractReader):
         self.selector = make_selector(selector)
 
         self.reader = fastavro.reader(self.fp)
-        self.schema = self.reader.schema
+        self.schema = self.reader.writer_schema
         if not self.schema:
             raise Exception("Missing Avro schema")
 

--- a/flow/record/adapter/avro.py
+++ b/flow/record/adapter/avro.py
@@ -71,8 +71,13 @@ class AvroWriter(AbstractWriter):
         self.writer.write(r._packdict())
 
     def flush(self):
-        if self.writer:
-            self.writer.flush()
+        if not self.writer:
+            self.writer = fastavro.write.Writer(
+                self.fp,
+                fastavro.parse_schema({"type": "record", "name": "empty"}),
+                codec=self.codec,
+            )
+        self.writer.flush()
 
     def close(self):
         if self.fp and not is_stdout(self.fp):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ avro = [
 test = [
     "lz4",
     "zstandard",
-    "fastavro[snappy]",
+    "fastavro",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,14 @@ elastic = [
 geoip = [
     "maxminddb",
 ]
+avro = [
+    "fastavro[snappy]",
+]
+test = [
+    "lz4",
+    "zstandard",
+    "fastavro[snappy]",
+]
 
 [project.scripts]
 rdump = "flow.record.tools.rdump:main"

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -1,0 +1,36 @@
+import datetime
+
+from flow.record import RecordDescriptor
+
+
+def generate_records(count=100):
+    TestRecordEmbedded = RecordDescriptor(
+        "test/embedded_record",
+        [
+            ("datetime", "dt"),
+        ],
+    )
+    TestRecord = RecordDescriptor(
+        "test/adapter",
+        [
+            ("uint32", "number"),
+            ("record", "record"),
+        ],
+    )
+
+    for i in range(count):
+        embedded = TestRecordEmbedded(datetime.datetime.utcnow())
+        yield TestRecord(number=i, record=embedded)
+
+
+def generate_plain_records(count=100):
+    TestRecord = RecordDescriptor(
+        "test/adapter/plain",
+        [
+            ("uint32", "number"),
+            ("datetime", "dt"),
+        ],
+    )
+
+    for i in range(count):
+        yield TestRecord(number=i, dt=datetime.datetime.utcnow())

--- a/tests/test_avro_adapter.py
+++ b/tests/test_avro_adapter.py
@@ -1,0 +1,51 @@
+from flow.record import RecordReader, RecordWriter
+
+from ._utils import generate_plain_records
+
+
+def test_avro_adapter(tmpdir):
+    json_file = tmpdir.join("records.avro")
+    record_adapter_path = "avro://{}".format(json_file)
+    writer = RecordWriter(record_adapter_path)
+    nr_records = 1337
+
+    for record in generate_plain_records(nr_records):
+        writer.write(record)
+    writer.flush()
+
+    nr_received_records = 0
+    reader = RecordReader(record_adapter_path)
+    for _ in reader:
+        nr_received_records += 1
+
+    assert nr_records == nr_received_records
+
+
+def test_avro_adapter_contextmanager(tmpdir):
+    json_file = tmpdir.join("records.avro")
+    record_adapter_path = "avro://{}".format(json_file)
+    with RecordWriter(record_adapter_path) as writer:
+        nr_records = 1337
+        for record in generate_plain_records(nr_records):
+            writer.write(record)
+
+    nr_received_records = 0
+    with RecordReader(record_adapter_path) as reader:
+        for _ in reader:
+            nr_received_records += 1
+
+        assert nr_records == nr_received_records
+
+
+def test_avro_adapter_empty(tmpdir):
+    json_file = tmpdir.join("records.avro")
+    record_adapter_path = "avro://{}".format(json_file)
+    with RecordWriter(record_adapter_path):
+        pass
+
+    nr_received_records = 0
+    with RecordReader(record_adapter_path) as reader:
+        for _ in reader:
+            nr_received_records += 1
+
+        assert nr_received_records == 0

--- a/tests/test_json_record_adapter.py
+++ b/tests/test_json_record_adapter.py
@@ -1,29 +1,10 @@
-import datetime
 import json
 
 import pytest
 
-from flow.record import RecordDescriptor, RecordReader, RecordWriter
+from flow.record import RecordReader, RecordWriter
 
-
-def generate_records(count=100):
-    TestRecordEmbedded = RecordDescriptor(
-        "test/embedded_record",
-        [
-            ("datetime", "dt"),
-        ],
-    )
-    TestRecord = RecordDescriptor(
-        "test/adapter",
-        [
-            ("uint32", "number"),
-            ("record", "record"),
-        ],
-    )
-
-    for i in range(count):
-        embedded = TestRecordEmbedded(datetime.datetime.utcnow())
-        yield TestRecord(number=i, record=embedded)
+from ._utils import generate_records
 
 
 def test_json_adapter(tmpdir):

--- a/tests/test_record_adapter.py
+++ b/tests/test_record_adapter.py
@@ -28,25 +28,7 @@ from flow.record.base import (
 )
 from flow.record.selector import CompiledSelector, Selector
 
-
-def generate_records(count=100):
-    TestRecordEmbedded = RecordDescriptor(
-        "test/embedded_record",
-        [
-            ("datetime", "dt"),
-        ],
-    )
-    TestRecord = RecordDescriptor(
-        "test/adapter",
-        [
-            ("uint32", "number"),
-            ("record", "record"),
-        ],
-    )
-
-    for i in range(count):
-        embedded = TestRecordEmbedded(datetime.datetime.utcnow())
-        yield TestRecord(number=i, record=embedded)
+from ._utils import generate_records
 
 
 def test_stream_writer_reader():

--- a/tests/test_record_adapter.py
+++ b/tests/test_record_adapter.py
@@ -1,4 +1,5 @@
 import datetime
+import platform
 import sys
 
 import pytest
@@ -84,6 +85,11 @@ def test_compressed_writer_reader(tmpdir, compression):
         pytest.skip("lz4 module not installed")
     if compression == "zstd" and not HAS_ZSTD:
         pytest.skip("zstandard module not installed")
+
+    if compression == "lz4" and platform.python_implementation() == "PyPy":
+        pytest.skip("lz4 module not supported on PyPy")
+    if compression == "zstd" and platform.python_implementation() == "PyPy":
+        pytest.skip("zstandard module not supported on PyPy")
 
     p = tmpdir.mkdir("{}-test".format(compression))
     path = str(p.join("test.records.{}".format(compression)))

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     pytest
     pytest-cov
     coverage
+extras = test
 commands =
 # Capturing output will fail on pypy, possibly due to this issue: https://github.com/pytest-dev/pytest/issues/5502
     pytest --basetemp="{envtmpdir}" {posargs:--color=yes --capture=no --cov=flow --cov-report=term-missing -v tests}


### PR DESCRIPTION
Initialize an empty Avro reader if we flush with no writer initialized yet. This ensures that the Avro header is always written so that the resulting file is a valid, but empty, Avro file.