### PR TITLE
fix issue in avro.py `argument of type 'NoneType' is not iterable`

### DIFF
--- a/flow/record/adapter/avro.py
+++ b/flow/record/adapter/avro.py
@@ -190,7 +190,7 @@ def avro_type_to_flow_type(ftype):
                 return "{}[]".format(item_type)
             else:
                 logical_type = t.get("logicalType")
-                if logical_type and "time" in logical_type or "date" in logical_type:
+                if logical_type and ("time" in logical_type or "date" in logical_type):
                     return "datetime"
 
         if t == "null":


### PR DESCRIPTION
The error occurs when parsing an avro schema and is caused by an invalid logical expression