### PR TITLE
Add skip flag to rdump

### DIFF
--- a/flow/record/tools/rdump.py
+++ b/flow/record/tools/rdump.py
@@ -205,6 +205,7 @@ def main(argv=None):
     seen_desc = set()
     islice_stop = (args.count + args.skip) if args.count else None
     record_iterator = islice(record_stream(args.src, selector), args.skip, islice_stop)
+    count = 0
     with RecordWriter(uri) as record_writer:
         for count, rec in enumerate(record_iterator, start=1):
             if args.record_source is not None:

--- a/flow/record/tools/rdump.py
+++ b/flow/record/tools/rdump.py
@@ -95,6 +95,7 @@ def main(argv=None):
     output = parser.add_argument_group("output control")
     output.add_argument("-f", "--format", metavar="FORMAT", help="Format string")
     output.add_argument("-c", "--count", type=int, help="Exit after COUNT records")
+    output.add_argument("--skip", metavar="COUNT", default=None, type=int, help="Skip the first COUNT records")
     output.add_argument("-w", "--writer", metavar="OUTPUT", default=None, help="Write records to output")
     output.add_argument("-m", "--mode", default=None, choices=("csv", "json", "jsonlines", "line"), help="Output mode")
     output.add_argument(
@@ -202,8 +203,11 @@ def main(argv=None):
     selector = make_selector(args.selector, not args.no_compile)
     seen_desc = set()
     count = 0
+    skip = args.skip if args.skip else 0
     with RecordWriter(uri) as record_writer:
         for count, rec in enumerate(record_stream(args.src, selector), start=1):
+            if count <= skip:
+                continue
             if args.record_source is not None:
                 rec._source = args.record_source
             if args.record_classification is not None:
@@ -227,7 +231,7 @@ def main(argv=None):
                 else:
                     record_writer.write(rec)
 
-            if args.count and count >= args.count:
+            if args.count and count >= (args.count + skip):
                 break
 
     if args.list:

--- a/flow/record/tools/rdump.py
+++ b/flow/record/tools/rdump.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 import logging
 import sys
 from importlib import import_module
+from itertools import islice
 from pathlib import Path
 from textwrap import indent
 from urllib.parse import parse_qsl, urlencode, urlparse
@@ -95,7 +96,7 @@ def main(argv=None):
     output = parser.add_argument_group("output control")
     output.add_argument("-f", "--format", metavar="FORMAT", help="Format string")
     output.add_argument("-c", "--count", type=int, help="Exit after COUNT records")
-    output.add_argument("--skip", metavar="COUNT", default=None, type=int, help="Skip the first COUNT records")
+    output.add_argument("--skip", metavar="COUNT", type=int, default=0, help="Skip the first COUNT records")
     output.add_argument("-w", "--writer", metavar="OUTPUT", default=None, help="Write records to output")
     output.add_argument("-m", "--mode", default=None, choices=("csv", "json", "jsonlines", "line"), help="Output mode")
     output.add_argument(
@@ -202,12 +203,10 @@ def main(argv=None):
 
     selector = make_selector(args.selector, not args.no_compile)
     seen_desc = set()
-    count = 0
-    skip = args.skip if args.skip else 0
+    islice_stop = (args.count + args.skip) if args.count else None
+    record_iterator = islice(record_stream(args.src, selector), args.skip, islice_stop)
     with RecordWriter(uri) as record_writer:
-        for count, rec in enumerate(record_stream(args.src, selector), start=1):
-            if count <= skip:
-                continue
+        for count, rec in enumerate(record_iterator, start=1):
             if args.record_source is not None:
                 rec._source = args.record_source
             if args.record_classification is not None:
@@ -230,9 +229,6 @@ def main(argv=None):
                         record_writer.write(record)
                 else:
                     record_writer.write(rec)
-
-            if args.count and count >= (args.count + skip):
-                break
 
     if args.list:
         print("Processed {} records".format(count))

--- a/tests/test_rdump.py
+++ b/tests/test_rdump.py
@@ -457,8 +457,17 @@ def test_rdump_headerless_csv(tmp_path, capsysbinary):
     ]
 
 
-@pytest.mark.parametrize(["count", "skip"], [(None, 2), (3, None), (2, 3)])
-def test_rdump_count_and_skip(tmp_path, capsysbinary, count, skip):
+@pytest.mark.parametrize(
+    ("total_records", "count", "skip", "expected_numbers"),
+    [
+        (10, None, 2, [2, 3, 4, 5, 6, 7, 8, 9]),
+        (10, 3, None, [0, 1, 2]),
+        (10, 2, 3, [3, 4]),
+        (10, None, 9, [9]),
+        (10, None, 10, []),
+    ],
+)
+def test_rdump_count_and_skip(tmp_path, capsysbinary, total_records, count, skip, expected_numbers):
     TestRecord = RecordDescriptor(
         "test/record",
         [
@@ -467,67 +476,36 @@ def test_rdump_count_and_skip(tmp_path, capsysbinary, count, skip):
         ],
     )
 
-    # Generate some test records and write them to a file
-    NUMBER_OF_TEST_RECORDS = 10
+    # Write test records to a file
     full_set_path = tmp_path / "test_full_set.records"
-    writer = RecordWriter(full_set_path)
-
-    test_records = []
-    for i in range(NUMBER_OF_TEST_RECORDS):
-        record = TestRecord(number=i, foo="bar" + "baz" * i)
-        test_records.append(record)
-        writer.write(record)
-    writer.close()
+    with RecordWriter(full_set_path) as writer:
+        for i in range(total_records):
+            record = TestRecord(number=i, foo="bar" + "baz" * i)
+            writer.write(record)
 
     rdump_parameters = []
-
-    # Work out where in the test_records list the first and last record will be once we have skipped and counted
-    expected_first_record_index = 0
-    expected_last_record_index = NUMBER_OF_TEST_RECORDS - 1
-    expected_number_of_records = min(count if count else NUMBER_OF_TEST_RECORDS, NUMBER_OF_TEST_RECORDS)
-    if skip and not count:
-        # Decrease the expected number of records, because we skipped some while not supplying a max count
-        expected_number_of_records -= skip
-    if count:
+    if count is not None:
         rdump_parameters.append(f"--count={count}")
-        expected_last_record_index = count - 1
-    if skip:
+    if skip is not None:
         rdump_parameters.append(f"--skip={skip}")
-        expected_first_record_index += skip
-        expected_last_record_index += skip
 
-    # We expect of rdump that if the count and skip parameters go further than the amount of records that are actually
-    # available, rdump will just stop reading/writing.
-    expected_last_record_index = min(NUMBER_OF_TEST_RECORDS - 1, expected_last_record_index)
-
-    # Read from the full records file using rdump with the skip and count parameters. We do this to test if rdump
-    # filters accordingly.
-    rdump_read_parameters = [str(full_set_path)] + rdump_parameters + ["--csv", "-F", "foo"]
-    rdump.main(rdump_read_parameters)
-
+    rdump.main([str(full_set_path), "--csv", "-F", "number"] + rdump_parameters)
     captured = capsysbinary.readouterr()
     assert captured.err == b""
 
+    # Skip csv header
     record_lines = captured.out.splitlines()[1:]
 
-    # Verify we have the amount of records that we expect, and that the first and last record have the correct value.
-    assert len(record_lines) == expected_number_of_records
-    assert test_records[expected_first_record_index].foo == record_lines[0].decode()
-    assert test_records[expected_last_record_index].foo == record_lines[-1].decode()
+    # Convert numbers to integers and validate
+    numbers = list(map(int, record_lines))
+    assert numbers == expected_numbers
 
-    # We also want to test if skip and count work correctly when writing records. Rdump should read the full recordfile,
-    # and then correctly write a subset (using count and skip) to the subset file
+    # Write records using --skip and --count to a new file
     subset_path = tmp_path / "test_subset.records"
-    rdump.main([str(full_set_path), "-w"] + [str(subset_path)] + rdump_parameters)
+    rdump.main([str(full_set_path), "-w", str(subset_path)] + rdump_parameters)
 
-    # Now we read the subsetted recordfile in its entirety, and check if the skip and count parameters were interpreted
-    # correctly.
-    rdump.main([str(subset_path), "--csv", "-F", "foo"])
-
-    captured = capsysbinary.readouterr()
-    assert captured.err == b""
-
-    record_lines = captured.out.splitlines()[1:]
-    assert len(record_lines) == expected_number_of_records
-    assert test_records[expected_first_record_index].foo == record_lines[0].decode()
-    assert test_records[expected_last_record_index].foo == record_lines[-1].decode()
+    # Read records from new file and validate
+    numbers = None
+    with RecordReader(subset_path) as reader:
+        numbers = [rec.number for rec in reader]
+    assert numbers == expected_numbers


### PR DESCRIPTION
Adds the ability to skip a number of records when reading or writing records using `rdump`.

The added test might be a bit overkill, open to feedback as to how it can be simplified.