### PR TITLE
Make datetime fieldtypes timezone aware

### DIFF
--- a/flow/record/adapter/elastic.py
+++ b/flow/record/adapter/elastic.py
@@ -99,7 +99,7 @@ class ElasticReader(AbstractReader):
         index: str = "records",
         http_compress: Union[str, bool] = True,
         selector: Union[None, Selector, CompiledSelector] = None,
-        **kwargs
+        **kwargs,
     ) -> None:
         self.index = index
         self.uri = uri

--- a/flow/record/base.py
+++ b/flow/record/base.py
@@ -12,7 +12,7 @@ import os
 import re
 import sys
 import warnings
-from datetime import datetime
+from datetime import datetime, timezone
 from itertools import zip_longest
 from typing import Any, Dict, Iterator, List, Mapping, Optional, Sequence, Tuple
 from urllib.parse import parse_qsl, urlparse
@@ -44,6 +44,7 @@ from .utils import to_native_str, to_str
 from .whitelist import WHITELIST, WHITELIST_TREE
 
 log = logging.getLogger(__package__)
+_utcnow = functools.partial(datetime.now, timezone.utc)
 
 RECORD_VERSION = 1
 RESERVED_FIELDS = OrderedDict(
@@ -422,7 +423,7 @@ def _generate_record_class(name: str, fields: Tuple[Tuple[str, str]]) -> type:
     _globals = {
         "Record": Record,
         "RECORD_VERSION": RECORD_VERSION,
-        "_utcnow": datetime.utcnow,
+        "_utcnow": _utcnow,
         "_zip_longest": zip_longest,
     }
     for field in all_fields.values():

--- a/flow/record/fieldtypes/__init__.py
+++ b/flow/record/fieldtypes/__init__.py
@@ -41,10 +41,10 @@ path_type = pathlib.PurePath
 
 
 def flow_record_tz(default_tz: str = "UTC") -> Optional[ZoneInfo]:
-    """Return a ZoneInfo object based on the ``FLOW_RECORD_TZ`` environment variable.
+    """Return a ``ZoneInfo`` object based on the ``FLOW_RECORD_TZ`` environment variable.
 
     Args:
-        default_tz: default timezone if ``FLOW_RECORD_TZ`` is not set (default: UTC)
+        default_tz: Default timezone if ``FLOW_RECORD_TZ`` is not set (default: UTC).
 
     Returns:
         None if ``FLOW_RECORD_TZ=NONE`` otherwise ``ZoneInfo(FLOW_RECORD_TZ)``
@@ -283,7 +283,7 @@ class datetime(_dt, FieldType):
             elif isinstance(arg, (int, float_type)):
                 obj = cls.fromtimestamp(arg, UTC)
             elif isinstance(arg, (_dt,)):
-                tzinfo = UTC if arg.tzinfo is None else arg.tzinfo
+                tzinfo = arg.tzinfo or UTC
                 obj = _dt.__new__(
                     cls,
                     arg.year,

--- a/flow/record/jsonpacker.py
+++ b/flow/record/jsonpacker.py
@@ -58,7 +58,7 @@ class JsonRecordPacker:
             }
             return serial
         if isinstance(obj, datetime):
-            serial = obj.strftime("%Y-%m-%dT%H:%M:%S.%f")
+            serial = obj.isoformat()
             return serial
         if isinstance(obj, fieldtypes.digest):
             return {

--- a/flow/record/stream.py
+++ b/flow/record/stream.py
@@ -191,7 +191,7 @@ class PathTemplateWriter:
 
     def rotate_existing_file(self, path):
         if os.path.exists(path):
-            now = datetime.datetime.utcnow()
+            now = datetime.datetime.now(datetime.timezone.utc)
             src = os.path.realpath(path)
 
             src_dir = os.path.dirname(src)
@@ -226,7 +226,7 @@ class PathTemplateWriter:
         return self.writer
 
     def write(self, record):
-        ts = record._generated or datetime.datetime.utcnow()
+        ts = record._generated or datetime.datetime.now(datetime.timezone.utc)
         path = self.path_template.format(name=self.name, record=record, ts=ts)
         rs = self.record_stream_for_path(path)
         rs.write(record)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 dependencies = [
     "msgpack>=0.5.2",
     "backports.zoneinfo[tzdata]; python_version<'3.9'",
+    "tzdata; platform_system=='Windows'",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "msgpack>=0.5.2",
+    "backports.zoneinfo[tzdata]; python_version<'3.9'",
 ]
 dynamic = ["version"]
 

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -19,7 +19,7 @@ def generate_records(count=100):
     )
 
     for i in range(count):
-        embedded = TestRecordEmbedded(datetime.datetime.utcnow())
+        embedded = TestRecordEmbedded(datetime.datetime.now(datetime.timezone.utc))
         yield TestRecord(number=i, record=embedded)
 
 
@@ -33,4 +33,4 @@ def generate_plain_records(count=100):
     )
 
     for i in range(count):
-        yield TestRecord(number=i, dt=datetime.datetime.utcnow())
+        yield TestRecord(number=i, dt=datetime.datetime.now(datetime.timezone.utc))

--- a/tests/test_fieldtypes.py
+++ b/tests/test_fieldtypes.py
@@ -941,10 +941,10 @@ def test_datetime_timezone_aware(tmp_path, record_filename):
 
 
 def test_datetime_comparisions():
-    with pytest.raises(TypeError, match="can't compare offset-naive and offset-aware datetimes"):
+    with pytest.raises(TypeError, match=".* compare .*naive"):
         assert dt("2023-01-01") > datetime(2022, 1, 1)
 
-    with pytest.raises(TypeError, match="can't compare offset-naive and offset-aware datetimes"):
+    with pytest.raises(TypeError, match=".* compare .*naive"):
         assert datetime(2022, 1, 1) < dt("2023-01-01")
 
     assert dt("2023-01-01") > datetime(2022, 1, 1, tzinfo=UTC)

--- a/tests/test_fieldtypes.py
+++ b/tests/test_fieldtypes.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
-import datetime
 import hashlib
 import os
 import pathlib
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -17,6 +17,8 @@ from flow.record.fieldtypes import (
 )
 from flow.record.fieldtypes import datetime as dt
 from flow.record.fieldtypes import fieldtype_for_value, net, uri
+
+UTC = timezone.utc
 
 INT64_MAX = (1 << 63) - 1
 INT32_MAX = (1 << 31) - 1
@@ -398,29 +400,29 @@ def test_datetime():
         ],
     )
 
-    now = datetime.datetime.utcnow()
+    now = datetime.now(UTC)
     r = TestRecord(now)
     assert r.ts == now
 
     r = TestRecord("2018-03-22T15:15:23")
-    assert r.ts == datetime.datetime(2018, 3, 22, 15, 15, 23)
+    assert r.ts == datetime(2018, 3, 22, 15, 15, 23, tzinfo=UTC)
 
     r = TestRecord("2018-03-22T15:15:23.000000")
-    assert r.ts == datetime.datetime(2018, 3, 22, 15, 15, 23)
+    assert r.ts == datetime(2018, 3, 22, 15, 15, 23, tzinfo=UTC)
 
     r = TestRecord("2018-03-22T15:15:23.123456")
-    assert r.ts == datetime.datetime(2018, 3, 22, 15, 15, 23, 123456)
+    assert r.ts == datetime(2018, 3, 22, 15, 15, 23, 123456, tzinfo=UTC)
 
-    dt = datetime.datetime(2018, 3, 22, 15, 15, 23, 123456)
+    dt = datetime(2018, 3, 22, 15, 15, 23, 123456, tzinfo=UTC)
     dt_str = dt.isoformat()
     r = TestRecord(dt_str)
     assert r.ts == dt
 
     r = TestRecord(1521731723)
-    assert r.ts == datetime.datetime(2018, 3, 22, 15, 15, 23)
+    assert r.ts == datetime(2018, 3, 22, 15, 15, 23, tzinfo=UTC)
 
     r = TestRecord(1521731723.123456)
-    assert r.ts == datetime.datetime(2018, 3, 22, 15, 15, 23, 123456)
+    assert r.ts == datetime(2018, 3, 22, 15, 15, 23, 123456, tzinfo=UTC)
 
     r = TestRecord("2018-03-22T15:15:23.123456")
     test = {r.ts: "Success"}
@@ -430,18 +432,18 @@ def test_datetime():
 @pytest.mark.parametrize(
     "value,expected_dt",
     [
-        ("2023-12-31T13:37:01.123456Z", datetime.datetime(2023, 12, 31, 13, 37, 1, 123456)),
-        ("2023-01-10T16:12:01+00:00", datetime.datetime(2023, 1, 10, 16, 12, 1)),
-        ("2023-01-10T16:12:01", datetime.datetime(2023, 1, 10, 16, 12, 1)),
-        ("2023-01-10T16:12:01Z", datetime.datetime(2023, 1, 10, 16, 12, 1)),
-        ("2022-12-01T13:00:23.499460Z", datetime.datetime(2022, 12, 1, 13, 0, 23, 499460)),
-        ("2019-09-26T07:58:30.996+0200", datetime.datetime(2019, 9, 26, 5, 58, 30, 996000)),
-        ("2011-11-04T00:05:23+04:00", datetime.datetime(2011, 11, 3, 20, 5, 23)),
-        ("2023-01-01T12:00:00+01:00", datetime.datetime(2023, 1, 1, 11, 0, 0, tzinfo=datetime.timezone.utc)),
-        ("2006-11-10T14:29:55.5851926", datetime.datetime(2006, 11, 10, 14, 29, 55, 585192)),
-        ("2006-11-10T14:29:55.585192699999999", datetime.datetime(2006, 11, 10, 14, 29, 55, 585192)),
-        (datetime.datetime(2023, 1, 1, tzinfo=datetime.timezone.utc), datetime.datetime(2023, 1, 1)),
-        (0, datetime.datetime(1970, 1, 1, 0, 0)),
+        ("2023-12-31T13:37:01.123456Z", datetime(2023, 12, 31, 13, 37, 1, 123456, tzinfo=UTC)),
+        ("2023-01-10T16:12:01+00:00", datetime(2023, 1, 10, 16, 12, 1, tzinfo=UTC)),
+        ("2023-01-10T16:12:01", datetime(2023, 1, 10, 16, 12, 1, tzinfo=UTC)),
+        ("2023-01-10T16:12:01Z", datetime(2023, 1, 10, 16, 12, 1, tzinfo=UTC)),
+        ("2022-12-01T13:00:23.499460Z", datetime(2022, 12, 1, 13, 0, 23, 499460, tzinfo=UTC)),
+        ("2019-09-26T07:58:30.996+0200", datetime(2019, 9, 26, 5, 58, 30, 996000, tzinfo=UTC)),
+        ("2011-11-04T00:05:23+04:00", datetime(2011, 11, 3, 20, 5, 23, tzinfo=UTC)),
+        ("2023-01-01T12:00:00+01:00", datetime(2023, 1, 1, 11, 0, 0, tzinfo=UTC)),
+        ("2006-11-10T14:29:55.5851926", datetime(2006, 11, 10, 14, 29, 55, 585192, tzinfo=UTC)),
+        ("2006-11-10T14:29:55.585192699999999", datetime(2006, 11, 10, 14, 29, 55, 585192, tzinfo=UTC)),
+        (datetime(2023, 1, 1, tzinfo=UTC), datetime(2023, 1, 1, tzinfo=UTC)),
+        (0, datetime(1970, 1, 1, 0, 0, tzinfo=UTC)),
     ],
 )
 def test_datetime_formats(tmp_path, value, expected_dt):
@@ -740,7 +742,7 @@ def test_fieldtype_for_value():
     assert fieldtype_for_value(1.337) == "float"
     assert fieldtype_for_value(b"\r\n") == "bytes"
     assert fieldtype_for_value("hello world") == "string"
-    assert fieldtype_for_value(datetime.datetime.now()) == "datetime"
+    assert fieldtype_for_value(datetime.now()) == "datetime"
     assert fieldtype_for_value([1, 2, 3, 4, 5]) == "string"
     assert fieldtype_for_value([1, 2, 3, 4, 5], None) is None
     assert fieldtype_for_value(object(), None) is None
@@ -775,7 +777,7 @@ def test_dynamic():
     assert r.value == [1, 2, 3]
     assert isinstance(r.value, flow.record.fieldtypes.stringlist)
 
-    now = datetime.datetime.utcnow()
+    now = datetime.now(UTC)
     r = TestRecord(now)
     assert r.value == now
     assert isinstance(r.value, flow.record.fieldtypes.datetime)
@@ -899,10 +901,62 @@ def test_datetime_handle_nanoseconds_without_timezone():
     d2 = dt("2006-11-10T14:29:55")
     assert isinstance(d1, dt)
     assert isinstance(d2, dt)
-    assert d1 == datetime.datetime(2006, 11, 10, 14, 29, 55, 585192)
+    assert d1 == datetime(2006, 11, 10, 14, 29, 55, 585192, tzinfo=UTC)
     assert d1.microsecond == 585192
-    assert d2 == datetime.datetime(2006, 11, 10, 14, 29, 55)
+    assert d2 == datetime(2006, 11, 10, 14, 29, 55, tzinfo=UTC)
     assert d2.microsecond == 0
+
+
+@pytest.mark.parametrize(
+    "record_filename",
+    [
+        "out.records.gz",
+        "out.records",
+        "out.json",
+        "out.jsonl",
+    ],
+)
+def test_datetime_timezone_aware(tmp_path, record_filename):
+    TestRecord = RecordDescriptor(
+        "test/tz",
+        [
+            ("datetime", "ts"),
+        ],
+    )
+    tz = timezone(timedelta(hours=1))
+    stamp = datetime.now(tz)
+
+    with RecordWriter(tmp_path / record_filename) as writer:
+        record = TestRecord(stamp)
+        writer.write(record)
+        assert record.ts == stamp
+        assert record.ts.utcoffset() == timedelta(hours=1)
+        assert record._generated.tzinfo == UTC
+
+    with RecordReader(tmp_path / record_filename) as reader:
+        for record in reader:
+            assert record.ts == stamp
+            assert record.ts.utcoffset() == timedelta(hours=1)
+            assert record._generated.tzinfo == UTC
+
+
+def test_datetime_comparisions():
+    with pytest.raises(TypeError, match="can't compare offset-naive and offset-aware datetimes"):
+        assert dt("2023-01-01") > datetime(2022, 1, 1)
+
+    with pytest.raises(TypeError, match="can't compare offset-naive and offset-aware datetimes"):
+        assert datetime(2022, 1, 1) < dt("2023-01-01")
+
+    assert dt("2023-01-01") > datetime(2022, 1, 1, tzinfo=UTC)
+    assert dt("2023-01-01") == datetime(2023, 1, 1, tzinfo=UTC)
+    assert dt("2023-01-01") == datetime(2023, 1, 1, tzinfo=UTC)
+    assert dt("2023-01-01T13:36") <= datetime(2023, 1, 1, 13, 37, tzinfo=UTC)
+    assert dt("2023-01-01T13:37") <= datetime(2023, 1, 1, 13, 37, tzinfo=UTC)
+    assert dt("2023-01-01T13:37") >= datetime(2023, 1, 1, 13, 36, tzinfo=UTC)
+    assert dt("2023-01-01T13:37") >= datetime(2023, 1, 1, 13, 37, tzinfo=UTC)
+    assert dt("2023-01-01T13:36") < datetime(2023, 1, 1, 13, 37, tzinfo=UTC)
+    assert dt("2023-01-01T13:37") > datetime(2023, 1, 1, 13, 36, tzinfo=UTC)
+    assert dt("2023-01-02") != datetime(2023, 3, 4, tzinfo=UTC)
 
 
 if __name__ == "__main__":

--- a/tests/test_json_packer.py
+++ b/tests/test_json_packer.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -9,7 +9,7 @@ from flow.record.exceptions import RecordDescriptorNotFound
 
 def test_record_in_record():
     packer = JsonRecordPacker()
-    dt = datetime.utcnow()
+    dt = datetime.now(timezone.utc)
 
     RecordA = RecordDescriptor(
         "test/record_a",

--- a/tests/test_multi_timestamp.py
+++ b/tests/test_multi_timestamp.py
@@ -1,7 +1,9 @@
-import datetime
+from datetime import datetime, timedelta, timezone
 
 from flow.record import RecordDescriptor, iter_timestamped_records
 from flow.record.base import merge_record_descriptors
+
+UTC = timezone.utc
 
 
 def test_multi_timestamp():
@@ -15,22 +17,22 @@ def test_multi_timestamp():
     )
 
     test_record = TestRecord(
-        ctime=datetime.datetime(2020, 1, 1, 1, 1, 1),
-        atime=datetime.datetime(2022, 11, 22, 13, 37, 37),
+        ctime=datetime(2020, 1, 1, 1, 1, 1),
+        atime=datetime(2022, 11, 22, 13, 37, 37),
         data="test",
     )
 
     ts_records = list(iter_timestamped_records(test_record))
 
     for rec in ts_records:
-        assert rec.ctime == datetime.datetime(2020, 1, 1, 1, 1, 1)
-        assert rec.atime == datetime.datetime(2022, 11, 22, 13, 37, 37)
+        assert rec.ctime == datetime(2020, 1, 1, 1, 1, 1, tzinfo=UTC)
+        assert rec.atime == datetime(2022, 11, 22, 13, 37, 37, tzinfo=UTC)
         assert rec.data == "test"
 
-    assert ts_records[0].ts == datetime.datetime(2020, 1, 1, 1, 1, 1)
+    assert ts_records[0].ts == datetime(2020, 1, 1, 1, 1, 1, tzinfo=UTC)
     assert ts_records[0].ts_description == "ctime"
 
-    assert ts_records[1].ts == datetime.datetime(2022, 11, 22, 13, 37, 37)
+    assert ts_records[1].ts == datetime(2022, 11, 22, 13, 37, 37, tzinfo=UTC)
     assert ts_records[1].ts_description == "atime"
 
 
@@ -58,7 +60,7 @@ def test_multi_timestamp_single_datetime():
     )
 
     test_record = TestRecord(
-        ctime=datetime.datetime(2020, 1, 1, 1, 1, 1),
+        ctime=datetime(2020, 1, 1, 1, 1, 1),
         data="test",
     )
     ts_records = list(iter_timestamped_records(test_record))
@@ -77,7 +79,7 @@ def test_multi_timestamp_ts_fieldname():
     )
 
     test_record = TestRecord(
-        ts=datetime.datetime(2020, 1, 1, 1, 1, 1),
+        ts=datetime(2020, 1, 1, 1, 1, 1),
         data="test",
     )
     ts_records = list(iter_timestamped_records(test_record))
@@ -95,7 +97,7 @@ def test_multi_timestamp_timezone():
         ],
     )
 
-    correct_ts = datetime.datetime(2023, 12, 31, 13, 37, 1, 123456, tzinfo=datetime.timezone.utc)
+    correct_ts = datetime(2023, 12, 31, 13, 37, 1, 123456, tzinfo=UTC)
 
     ts_notations = [
         correct_ts,
@@ -127,8 +129,8 @@ def test_multi_timestamp_descriptor_cache():
     merge_record_descriptors.cache_clear()
     for i in range(10):
         test_record = TestRecord(
-            ctime=datetime.datetime.utcnow() + datetime.timedelta(hours=69),
-            atime=datetime.datetime.utcnow() + datetime.timedelta(hours=420),
+            ctime=datetime.now(UTC) + timedelta(hours=69),
+            atime=datetime.now(UTC) + timedelta(hours=420),
             count=i,
             data=f"test {i}",
         )

--- a/tests/test_packer.py
+++ b/tests/test_packer.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -6,6 +6,8 @@ from flow.record import RecordDescriptor, RecordPacker, fieldtypes
 from flow.record.exceptions import RecordDescriptorNotFound
 from flow.record.fieldtypes import uri
 from flow.record.packer import RECORD_PACK_EXT_TYPE
+
+UTC = timezone.utc
 
 
 def test_uri_packing():
@@ -151,7 +153,7 @@ def test_dynamic_packer():
     assert r.value == [1, True, b"b", "u"]
     assert isinstance(r.value, fieldtypes.stringlist)
 
-    now = datetime.datetime.utcnow()
+    now = datetime.now(UTC)
     t = TestRecord(now)
     data = packer.pack(t)
     r = packer.unpack(data)
@@ -195,7 +197,7 @@ def test_pack_digest():
 
 def test_record_in_record():
     packer = RecordPacker()
-    dt = datetime.datetime.utcnow()
+    dt = datetime.now(UTC)
 
     RecordA = RecordDescriptor(
         "test/record_a",

--- a/tests/test_rdump.py
+++ b/tests/test_rdump.py
@@ -4,10 +4,13 @@ import json
 import os
 import platform
 import subprocess
+from unittest import mock
 
 import pytest
 
+import flow.record.fieldtypes
 from flow.record import RecordDescriptor, RecordReader, RecordWriter
+from flow.record.fieldtypes import flow_record_tz
 from flow.record.tools import rdump
 
 
@@ -509,3 +512,48 @@ def test_rdump_count_and_skip(tmp_path, capsysbinary, total_records, count, skip
     with RecordReader(subset_path) as reader:
         numbers = [rec.number for rec in reader]
     assert numbers == expected_numbers
+
+
+@pytest.mark.parametrize(
+    "date_str,tz,expected_date_str",
+    [
+        ("2023-08-02T22:28:06.12345+01:00", None, "2023-08-02 21:28:06.123450+00:00"),
+        ("2023-08-02T22:28:06.12345+01:00", "NONE", "2023-08-02 22:28:06.123450+01:00"),
+        ("2023-08-02T22:28:06.12345-08:00", "NONE", "2023-08-02 22:28:06.123450-08:00"),
+        ("2023-08-02T20:51:32.123456+00:00", "Europe/Amsterdam", "2023-08-02 22:51:32.123456+02:00"),
+        ("2023-08-02T20:51:32.123456+00:00", "America/New_York", "2023-08-02 16:51:32.123456-04:00"),
+    ],
+)
+@pytest.mark.parametrize(
+    "rdump_params",
+    [
+        [],
+        ["--mode=csv"],
+        ["--mode=line"],
+    ],
+)
+def test_flow_record_tz_output(tmp_path, capsys, date_str, tz, expected_date_str, rdump_params):
+    TestRecord = RecordDescriptor(
+        "test/flow_record_tz",
+        [
+            ("datetime", "stamp"),
+        ],
+    )
+    with RecordWriter(tmp_path / "test.records") as writer:
+        writer.write(TestRecord(stamp=date_str))
+
+    env_dict = {}
+    if tz is not None:
+        env_dict["FLOW_RECORD_TZ"] = tz
+
+    with mock.patch.dict(os.environ, env_dict, clear=True):
+        # Reconfigure DISPLAY_TZINFO
+        flow.record.fieldtypes.DISPLAY_TZINFO = flow_record_tz("UTC")
+
+        rdump.main([str(tmp_path / "test.records")] + rdump_params)
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        assert expected_date_str in captured.out
+
+    # restore DISPLAY_TZINFO just in case
+    flow.record.fieldtypes.DISPLAY_TZINFO = flow_record_tz("UTC")

--- a/tests/test_record_adapter.py
+++ b/tests/test_record_adapter.py
@@ -203,7 +203,7 @@ def test_record_writer_stdout():
 def test_record_adapter_archive(tmpdir):
     # archive some records, using "testing" as name
     writer = RecordWriter("archive://{}?name=testing".format(tmpdir))
-    dt = datetime.datetime.utcnow()
+    dt = datetime.datetime.now(datetime.timezone.utc)
     count = 0
     for rec in generate_records():
         writer.write(rec)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,10 +1,10 @@
 import codecs
-import datetime
 import json
 import os
 import pathlib
 import subprocess
 import sys
+from datetime import datetime, timezone
 from unittest.mock import mock_open, patch
 
 import msgpack
@@ -32,7 +32,7 @@ from flow.record.utils import is_stdout
 def test_datetime_serialization():
     packer = RecordPacker()
 
-    now = datetime.datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     for tz in ["UTC", "Europe/Amsterdam"]:
         os.environ["TZ"] = tz

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -449,7 +449,7 @@ def test_record_in_records():
     )
 
     test_str = "this is a test"
-    dt = datetime.utcnow()
+    dt = datetime.now(timezone.utc)
     record_a = RecordA(some_dt=dt, field=test_str)
     record_b = RecordB(record=record_a, some_dt=dt)
 

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ deps =
     vermin
 commands =
     flake8 flow tests
-    vermin -t=3.7- --no-tips --lint flow tests
+    vermin -t=3.7- --no-tips --lint --exclude zoneinfo flow tests
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
This PR will add the following:

- Record datetime fields are now offset-aware by default
- Naive datetime fields are converted to UTC
- Support for packing/unpacking aware datetimes

Note that comparing to naive datetime objects will now break and is also in line with default Python behaviour

To ensure uniform datetime field output they are always displayed in UTC
To disable this behaviour you can set the environment variable  `FLOW_RECORD_TZ=NONE` 
