### PR TITLE
Add support for Splunk HTTP Event Collector

### DIFF
--- a/flow/record/adapter/splunk.py
+++ b/flow/record/adapter/splunk.py
@@ -1,18 +1,41 @@
+import json
 import logging
 import socket
+import uuid
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Optional
+from urllib.parse import urlparse
+
+try:
+    import requests
+    import urllib3
+
+    urllib3.disable_warnings()
+    HAS_REQUESTS = True
+except ImportError:
+    HAS_REQUESTS = False
 
 from flow.record.adapter import AbstractReader, AbstractWriter
+from flow.record.base import Record
+from flow.record.jsonpacker import JsonRecordPacker
 from flow.record.utils import to_base64, to_bytes, to_str
 
 __usage__ = """
 Splunk output adapter (writer only)
 ---
-Write usage: rdump -w splunk://[IP]:[PORT]?tag=[TAG]
+Write usage: rdump -w splunk+[PROTOCOL]://[IP]:[PORT]?tag=[TAG]&token=[TOKEN]&sourcetype=[SOURCETYPE]
 [IP]:[PORT]: ip and port to a splunk instance
 [TAG]: optional value to add as "rdtag" output field when writing
+[TOKEN]: Authentication token for sending data over HTTP(S)
+[SOURCETYPE]: Set sourcetype of data. Defaults to records, but can also be set to JSON.
+[SSL_VERIFY]: Whether to verify the server certificate when sending data over HTTP(S). Defaults to True.
 """
 
 log = logging.getLogger(__package__)
+
+# Amount of records to bindle into a single request when sending data over HTTP(S).
+RECORD_BUFFER_LIMIT = 20
 
 RESERVED_SPLUNK_FIELDS = set(
     [
@@ -27,7 +50,18 @@ RESERVED_SPLUNK_FIELDS = set(
 )
 
 
-def splunkify(record, tag=None):
+class SPLUNK_PROTOCOLS(Enum):
+    HTTP = "http"
+    HTTPS = "https"
+    TCP = "tcp"
+
+
+class SPLUNK_SOURCETYPES(Enum):
+    JSON = "json"
+    RECORDS = "records"
+
+
+def splunkify_key_value(record: Record, tag: Optional[str] = None) -> str:
     ret = []
 
     ret.append(f'type="{record._desc.name}"')
@@ -51,38 +85,161 @@ def splunkify(record, tag=None):
     return " ".join(ret)
 
 
+def splunkify_json(packer: JsonRecordPacker, record: Record, tag: Optional[str] = None) -> str:
+    ret = {}
+
+    indexer_fields = {
+        ("host", "host"),
+        ("host", "hostname"),
+        ("time", "ts"),
+        ("source", "_source"),
+    }
+    record_as_dict = packer.pack_obj(record)
+    record_as_dict["rdtag"] = tag
+    for dest_field, source_field in indexer_fields:
+        if hasattr(record, source_field):
+            val = getattr(record, source_field)
+            if val:
+                if isinstance(val, datetime):
+                    # Convert datetime objects to epoch timestamp for reserved fields.
+                    epoch = (val - datetime(1970, 1, 1, tzinfo=timezone.utc)).total_seconds()
+                    ret[dest_field] = epoch
+                    continue
+                ret[dest_field] = to_str(val)
+
+    for field in RESERVED_SPLUNK_FIELDS:
+        if field not in record_as_dict.keys():
+            continue
+        new_field = f"rd_{field}"
+        val = record_as_dict[field]
+        del record_as_dict[field]
+        record_as_dict[new_field] = val
+
+    ret["event"] = record_as_dict
+    return json.dumps(ret, default=packer.pack_obj)
+
+
 class SplunkWriter(AbstractWriter):
     sock = None
 
-    def __init__(self, path, tag=None, **kwargs):
-        p = path.strip("/").split("/")
-        host, port = p[0].split(":")
-        port = int(port)
+    def __init__(
+        self,
+        uri: str,
+        tag: Optional[str] = None,
+        token: Optional[str] = None,
+        sourcetype: Optional[str] = None,
+        ssl_verify: bool = True,
+        **kwargs,
+    ):
+        if "://" not in uri:
+            uri = f"tcp://{uri}"
+        parsed_url = urlparse(uri)
+        url_scheme = parsed_url.scheme.lower()
+        if sourcetype is None:
+            log.warning("No sourcetype provided, assuming 'records' sourcetype.")
+            sourcetype = SPLUNK_SOURCETYPES.RECORDS.value
+        self.protocol = next((protocol for protocol in SPLUNK_PROTOCOLS if protocol.value == url_scheme), None)
+        self.sourcetype = next((source for source in SPLUNK_SOURCETYPES if source.value == sourcetype), None)
 
+        if not self.sourcetype:
+            raise ValueError(f"Unsupported source type {sourcetype}.")
+        if not self.protocol:
+            raise ValueError(f"Unsupported protocol {url_scheme}.")
+        if self.protocol == SPLUNK_PROTOCOLS.TCP and self.sourcetype != SPLUNK_SOURCETYPES.RECORDS:
+            raise ValueError("For sending data to splunk over TCP, only the 'records' sourcetype is allowed.")
+
+        self.host = parsed_url.hostname
+        self.port = parsed_url.port
         self.tag = tag
-        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM, socket.SOL_TCP)
-        self.sock.connect((host, port))
-        self.descriptors = {}
+        self.record_buffer = set()
         self._warned = False
+        self.packer = None
 
-    def write(self, record):
+        if self.protocol == SPLUNK_PROTOCOLS.TCP:
+            self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM, socket.SOL_TCP)
+            self.sock.connect((self.host, self.port))
+
+        elif self.protocol in [SPLUNK_PROTOCOLS.HTTP, SPLUNK_PROTOCOLS.HTTPS]:
+            if not HAS_REQUESTS:
+                raise ImportError("The requests library is required for sending data over HTTP(S).")
+            self.token = token
+
+            # Assume verify=True unless specified otherwise.
+            self.verify = not (str(ssl_verify).lower() in ("0", "false"))
+
+            scheme = self.protocol.value
+            endpoint = "event" if self.sourcetype != SPLUNK_SOURCETYPES.RECORDS else "raw"
+            port = f":{self.port}" if self.port else ""
+            self.url = f"{scheme}://{self.host}{port}/services/collector/{endpoint}?auto_extract_timestamp=true"
+            if not self.token:
+                raise ValueError("An authorization token is required for the HTTP collector.")
+            if not self.token.startswith("Splunk "):
+                self.token = "Splunk " + self.token
+            if not self.verify:
+                log.warning("Certification verification is disabled.")
+            self.headers = {
+                "Authorization": self.token,
+                "X-Splunk-Request-Channel": str(uuid.uuid4()),
+            }
+
+        if self.sourcetype == SPLUNK_SOURCETYPES.JSON:
+            self.packer = JsonRecordPacker(indent=4, pack_descriptors=False)
+
+    def _send_http(self, data: bytes, flush: bool = False) -> None:
+        if data:
+            self.record_buffer.add(data)
+        if len(self.record_buffer) < RECORD_BUFFER_LIMIT and not flush:
+            return
+        buf = b""
+        for record_data in self.record_buffer:
+            buf += record_data + b"\n"
+
+        if not len(buf):
+            return
+
+        # Remove the last newline as it is duplicate.
+        buf = buf[:-1]
+
+        # Empty the set
+        self.record_buffer.clear()
+        response = requests.post(self.url, headers=self.headers, verify=self.verify, data=buf)
+        if response.status_code != 200:
+            raise Exception(f"{response.text} ({response.status_code})")
+
+    def _send_tcp(self, data: bytes) -> None:
+        self.sock.sendall(data)
+
+    def write(self, record: Record) -> None:
         if not self._warned and "rdtag" in record._desc.fields:
             self._warned = True
             log.warning(
                 "Record has 'rdtag' field which conflicts with the Splunk adapter -- "
                 "Splunk output will have duplicate 'rdtag' fields",
             )
-        rec = splunkify(record, tag=self.tag)
+        if self.sourcetype == SPLUNK_SOURCETYPES.RECORDS:
+            rec = splunkify_key_value(record, self.tag)
+        else:
+            rec = splunkify_json(self.packer, record, self.tag)
+
+        # Trail with a newline for line breaking.
         data = to_bytes(rec) + b"\n"
-        self.sock.sendall(data)
 
-    def flush(self):
-        pass
+        if self.protocol == SPLUNK_PROTOCOLS.TCP:
+            self._send_tcp(data)
+        else:
+            self._send_http(data)
 
-    def close(self):
+    def flush(self) -> None:
+        if self.protocol in [SPLUNK_PROTOCOLS.HTTP, SPLUNK_PROTOCOLS.HTTPS]:
+            self._send_http(None, flush=True)
+
+    def close(self) -> None:
+        # For TCP
         if self.sock:
             self.sock.close()
         self.sock = None
+        # For HTTP(S)
+        self.flush()
 
 
 class SplunkReader(AbstractReader):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ duckdb = [
     "duckdb",
     "pytz", # duckdb requires pytz for timezone support
 ]
+splunk = [
+    "httpx",
+]
 test = [
     "flow.record[compression]",
     "flow.record[avro]",

--- a/tests/test_splunk_adapter.py
+++ b/tests/test_splunk_adapter.py
@@ -106,25 +106,23 @@ def test_splunkify_source_field():
     ):
         test_record_descriptor = RecordDescriptor(
             "test/record",
-            [],
+            [("string", "source")],
         )
 
-        test_record = test_record_descriptor()
-        test_record._source = "test_source"
+        test_record = test_record_descriptor(source="file_on_target")
+        test_record._source = "path_of_target"
 
         output_key_value = splunkify_key_value(test_record)
         output_json = splunkify_json(JSON_PACKER, test_record)
         assert output_key_value.startswith(
-            f'rdtype="test/record" rdtag=None source="test_source" {RESERVED_FIELDS_KEY_VALUE_SUFFIX}'
+            'rdtype="test/record" rdtag=None source="path_of_target" rd_source="file_on_target" '
+            + RESERVED_FIELDS_KEY_VALUE_SUFFIX
         )
 
         assert json.loads(output_json) == {
-            "source": "test_source",
+            "source": "path_of_target",
             "event": dict(
-                {
-                    "rdtag": None,
-                    "rdtype": "test/record",
-                },
+                {"rdtag": None, "rdtype": "test/record", "rd_source": "file_on_target"},
                 **BASE_FIELD_VALUES,
             ),
         }

--- a/tests/test_splunk_adapter.py
+++ b/tests/test_splunk_adapter.py
@@ -1,12 +1,42 @@
-from unittest import mock
+import datetime
+import json
+import sys
+from typing import Iterator
+from unittest.mock import ANY, MagicMock, patch
+
+import pytest
 
 import flow.record.adapter.splunk
 from flow.record import RecordDescriptor
-from flow.record.adapter.splunk import splunkify
+from flow.record.adapter.splunk import (
+    SPLUNK_PROTOCOLS,
+    SplunkWriter,
+    splunkify_json,
+    splunkify_key_value,
+)
+from flow.record.jsonpacker import JsonRecordPacker
+
+BASE_FIELD_VALUES = {
+    "_classification": None,
+    "_generated": ANY,
+    "_source": None,
+    "_version": 1,
+}
+
+JSON_PACKER = JsonRecordPacker(pack_descriptors=False)
+
+
+@pytest.fixture
+def mock_requests_package(monkeypatch: pytest.MonkeyPatch) -> Iterator[MagicMock]:
+    with monkeypatch.context() as m:
+        mock_requests = MagicMock()
+        m.setitem(sys.modules, "requests", mock_requests)
+
+        yield mock_requests
 
 
 def test_splunkify_reserved_field():
-    with mock.patch.object(
+    with patch.object(
         flow.record.adapter.splunk,
         "RESERVED_SPLUNK_FIELDS",
         set(["foo"]),
@@ -18,12 +48,15 @@ def test_splunkify_reserved_field():
 
         test_record = test_record_descriptor(foo="bar")
 
-        output = splunkify(test_record)
-        assert output == 'type="test/record" rdtag=None rd_foo="bar"'
+        output_key_value = splunkify_key_value(test_record)
+        output_json = splunkify_json(JSON_PACKER, test_record)
+        assert output_key_value == 'type="test/record" rdtag=None rd_foo="bar"'
+
+        assert json.loads(output_json) == {"event": dict({"rdtag": None, "rd_foo": "bar"}, **BASE_FIELD_VALUES)}
 
 
 def test_splunkify_normal_field():
-    with mock.patch.object(
+    with patch.object(
         flow.record.adapter.splunk,
         "RESERVED_SPLUNK_FIELDS",
         set(),
@@ -35,12 +68,14 @@ def test_splunkify_normal_field():
 
         test_record = test_record_descriptor(foo="bar")
 
-        output = splunkify(test_record)
-        assert output == 'type="test/record" rdtag=None foo="bar"'
+        output_key_value = splunkify_key_value(test_record)
+        output_json = splunkify_json(JSON_PACKER, test_record)
+        assert output_key_value == 'type="test/record" rdtag=None foo="bar"'
+        assert json.loads(output_json) == {"event": dict({"rdtag": None, "foo": "bar"}, **BASE_FIELD_VALUES)}
 
 
 def test_splunkify_rdtag_field():
-    with mock.patch.object(
+    with patch.object(
         flow.record.adapter.splunk,
         "RESERVED_SPLUNK_FIELDS",
         set(),
@@ -49,12 +84,14 @@ def test_splunkify_rdtag_field():
 
         test_record = test_record_descriptor()
 
-        output = splunkify(test_record, tag="bar")
-        assert output == 'type="test/record" rdtag="bar"'
+        output_key_value = splunkify_key_value(test_record, tag="bar")
+        output_json = splunkify_json(JSON_PACKER, test_record, tag="bar")
+        assert output_key_value == 'type="test/record" rdtag="bar"'
+        assert json.loads(output_json) == {"event": dict({"rdtag": "bar"}, **BASE_FIELD_VALUES)}
 
 
 def test_splunkify_none_field():
-    with mock.patch.object(
+    with patch.object(
         flow.record.adapter.splunk,
         "RESERVED_SPLUNK_FIELDS",
         set(),
@@ -66,12 +103,14 @@ def test_splunkify_none_field():
 
         test_record = test_record_descriptor()
 
-        output = splunkify(test_record)
-        assert output == 'type="test/record" rdtag=None foo=None'
+        output_key_value = splunkify_key_value(test_record)
+        output_json = splunkify_json(JSON_PACKER, test_record)
+        assert output_key_value == 'type="test/record" rdtag=None foo=None'
+        assert json.loads(output_json) == {"event": dict({"rdtag": None, "foo": None}, **BASE_FIELD_VALUES)}
 
 
 def test_splunkify_byte_field():
-    with mock.patch.object(
+    with patch.object(
         flow.record.adapter.splunk,
         "RESERVED_SPLUNK_FIELDS",
         set(),
@@ -83,12 +122,14 @@ def test_splunkify_byte_field():
 
         test_record = test_record_descriptor(foo=b"bar")
 
-        output = splunkify(test_record)
-        assert output == 'type="test/record" rdtag=None foo="YmFy"'
+        output_key_value = splunkify_key_value(test_record)
+        output_json = splunkify_json(JSON_PACKER, test_record)
+        assert output_key_value == 'type="test/record" rdtag=None foo="YmFy"'
+        assert json.loads(output_json) == {"event": dict({"rdtag": None, "foo": "YmFy"}, **BASE_FIELD_VALUES)}
 
 
 def test_splunkify_backslash_quote_field():
-    with mock.patch.object(
+    with patch.object(
         flow.record.adapter.splunk,
         "RESERVED_SPLUNK_FIELDS",
         set(),
@@ -100,5 +141,137 @@ def test_splunkify_backslash_quote_field():
 
         test_record = test_record_descriptor(foo=b'\\"')
 
-        output = splunkify(test_record)
+        output = splunkify_key_value(test_record)
+        output_json = splunkify_json(JSON_PACKER, test_record)
         assert output == 'type="test/record" rdtag=None foo="\\\\\\""'
+        assert json.loads(output_json) == {"event": dict({"rdtag": None, "foo": '\\"'}, **BASE_FIELD_VALUES)}
+
+
+def test_splunkify_json_special_fields():
+    with patch.object(
+        flow.record.adapter.splunk,
+        "RESERVED_SPLUNK_FIELDS",
+        set(),
+    ):
+        test_record_descriptor = RecordDescriptor(
+            "test/record",
+            [
+                ("datetime", "ts"),
+                ("string", "hostname"),
+                ("string", "foo"),
+            ],
+        )
+
+        # Datetimes should be converted to epoch
+        test_record = test_record_descriptor(ts=datetime.datetime(1970, 1, 1, 4, 0), hostname="RECYCLOPS", foo="bar")
+
+        output = splunkify_json(JSON_PACKER, test_record)
+        assert '"time": 14400.0,' in output
+        assert '"host": "RECYCLOPS"' in output
+
+
+def test_tcp_protocol():
+    with patch("socket.socket") as mock_socket:
+        tcp_writer = SplunkWriter("splunk:1337")
+        assert tcp_writer.host == "splunk"
+        assert tcp_writer.port == 1337
+        assert tcp_writer.protocol == SPLUNK_PROTOCOLS.TCP
+
+        mock_socket.assert_called()
+        mock_socket.return_value.connect.assert_called_with(("splunk", 1337))
+
+        test_record_descriptor = RecordDescriptor(
+            "test/record",
+            [("string", "foo")],
+        )
+
+        test_record = test_record_descriptor(foo="bar")
+        tcp_writer.write(test_record)
+        mock_socket.return_value.sendall.assert_called_with(b'type="test/record" rdtag=None foo="bar"\n')
+
+
+def test_https_protocol_records_sourcetype(mock_requests_package: MagicMock):
+    if "flow.record.adapter.splunk" in sys.modules:
+        del sys.modules["flow.record.adapter.splunk"]
+
+    from flow.record.adapter.splunk import (
+        SPLUNK_PROTOCOLS,
+        SPLUNK_SOURCETYPES,
+        SplunkWriter,
+    )
+
+    with patch.object(
+        flow.record.adapter.splunk,
+        "HAS_REQUESTS",
+        True,
+    ):
+        mock_requests_package.post.return_value.status_code = 200
+        https_writer = SplunkWriter("https://splunk:8088", token="password123")
+
+        assert https_writer.host == "splunk"
+        assert https_writer.protocol == SPLUNK_PROTOCOLS.HTTPS
+        assert https_writer.sourcetype == SPLUNK_SOURCETYPES.RECORDS
+        assert https_writer.verify is True
+        assert https_writer.url == "https://splunk:8088/services/collector/raw?auto_extract_timestamp=true"
+        assert https_writer.headers["Authorization"] == "Splunk password123"
+        assert "X-Splunk-Request-Channel" in https_writer.headers
+
+        test_record_descriptor = RecordDescriptor(
+            "test/record",
+            [("string", "foo")],
+        )
+
+        test_record = test_record_descriptor(foo="bar")
+        https_writer.write(test_record)
+        mock_requests_package.post.assert_not_called()
+
+        https_writer.close()
+        mock_requests_package.post.assert_called_with(
+            "https://splunk:8088/services/collector/raw?auto_extract_timestamp=true",
+            headers={
+                "Authorization": "Splunk password123",
+                "X-Splunk-Request-Channel": ANY,
+            },
+            verify=True,
+            data=b'type="test/record" rdtag=None foo="bar"\n',
+        )
+
+
+def test_https_protocol_json_sourcetype(mock_requests_package: MagicMock):
+    if "flow.record.adapter.splunk" in sys.modules:
+        del sys.modules["flow.record.adapter.splunk"]
+
+    from flow.record.adapter.splunk import SplunkWriter
+
+    with patch.object(
+        flow.record.adapter.splunk,
+        "HAS_REQUESTS",
+        True,
+    ):
+        mock_requests_package.post.return_value.status_code = 200
+
+        https_writer = SplunkWriter("https://splunk:8088", token="password123", sourcetype="json")
+
+        test_record_descriptor = RecordDescriptor(
+            "test/record",
+            [("string", "foo")],
+        )
+
+        test_record = test_record_descriptor(foo="bar")
+        https_writer.write(test_record)
+        mock_requests_package.post.assert_not_called()
+
+        https_writer.close()
+        mock_requests_package.post.assert_called_with(
+            "https://splunk:8088/services/collector/event?auto_extract_timestamp=true",
+            headers={
+                "Authorization": "Splunk password123",
+                "X-Splunk-Request-Channel": ANY,
+            },
+            verify=True,
+            data=ANY,
+        )
+
+        _, kwargs = mock_requests_package.post.call_args
+        called_with_data = kwargs["data"]
+        assert json.loads(called_with_data) == {"event": dict({"rdtag": None, "foo": "bar"}, **BASE_FIELD_VALUES)}

--- a/tests/test_splunk_adapter.py
+++ b/tests/test_splunk_adapter.py
@@ -25,6 +25,9 @@ BASE_FIELD_VALUES = {
 
 JSON_PACKER = JsonRecordPacker(pack_descriptors=False)
 
+# Reserved fields is an ordered dict so we can make assertions with a static order of reserved fields.
+RESERVED_FIELDS_KEY_VALUE_SUFFIX = '_source=None _classification=None _generated="'
+
 
 @pytest.fixture
 def mock_requests_package(monkeypatch: pytest.MonkeyPatch) -> Iterator[MagicMock]:
@@ -50,13 +53,16 @@ def test_splunkify_reserved_field():
 
         output_key_value = splunkify_key_value(test_record)
         output_json = splunkify_json(JSON_PACKER, test_record)
-        assert output_key_value == 'type="test/record" rdtag=None rd_foo="bar"'
+
+        assert output_key_value.startswith(
+            f'rdtype="test/record" rdtag=None rd_foo="bar" {RESERVED_FIELDS_KEY_VALUE_SUFFIX}'
+        )
 
         assert json.loads(output_json) == {
             "event": dict(
                 {
                     "rdtag": None,
-                    "type": "test/record",
+                    "rdtype": "test/record",
                     "rd_foo": "bar",
                 },
                 **BASE_FIELD_VALUES,
@@ -79,12 +85,14 @@ def test_splunkify_normal_field():
 
         output_key_value = splunkify_key_value(test_record)
         output_json = splunkify_json(JSON_PACKER, test_record)
-        assert output_key_value == 'type="test/record" rdtag=None foo="bar"'
+        assert output_key_value.startswith(
+            f'rdtype="test/record" rdtag=None foo="bar" {RESERVED_FIELDS_KEY_VALUE_SUFFIX}'
+        )
         assert json.loads(output_json) == {
             "event": dict(
                 {
                     "rdtag": None,
-                    "type": "test/record",
+                    "rdtype": "test/record",
                     "foo": "bar",
                 },
                 **BASE_FIELD_VALUES,
@@ -104,12 +112,12 @@ def test_splunkify_rdtag_field():
 
         output_key_value = splunkify_key_value(test_record, tag="bar")
         output_json = splunkify_json(JSON_PACKER, test_record, tag="bar")
-        assert output_key_value == 'type="test/record" rdtag="bar"'
+        assert output_key_value.startswith(f'rdtype="test/record" rdtag="bar" {RESERVED_FIELDS_KEY_VALUE_SUFFIX}')
         assert json.loads(output_json) == {
             "event": dict(
                 {
                     "rdtag": "bar",
-                    "type": "test/record",
+                    "rdtype": "test/record",
                 },
                 **BASE_FIELD_VALUES,
             )
@@ -131,12 +139,14 @@ def test_splunkify_none_field():
 
         output_key_value = splunkify_key_value(test_record)
         output_json = splunkify_json(JSON_PACKER, test_record)
-        assert output_key_value == 'type="test/record" rdtag=None foo=None'
+        assert output_key_value.startswith(
+            f'rdtype="test/record" rdtag=None foo=None {RESERVED_FIELDS_KEY_VALUE_SUFFIX}'
+        )
         assert json.loads(output_json) == {
             "event": dict(
                 {
                     "rdtag": None,
-                    "type": "test/record",
+                    "rdtype": "test/record",
                     "foo": None,
                 },
                 **BASE_FIELD_VALUES,
@@ -159,12 +169,14 @@ def test_splunkify_byte_field():
 
         output_key_value = splunkify_key_value(test_record)
         output_json = splunkify_json(JSON_PACKER, test_record)
-        assert output_key_value == 'type="test/record" rdtag=None foo="YmFy"'
+        assert output_key_value.startswith(
+            f'rdtype="test/record" rdtag=None foo="YmFy" {RESERVED_FIELDS_KEY_VALUE_SUFFIX}'
+        )
         assert json.loads(output_json) == {
             "event": dict(
                 {
                     "rdtag": None,
-                    "type": "test/record",
+                    "rdtype": "test/record",
                     "foo": "YmFy",
                 },
                 **BASE_FIELD_VALUES,
@@ -187,12 +199,12 @@ def test_splunkify_backslash_quote_field():
 
         output = splunkify_key_value(test_record)
         output_json = splunkify_json(JSON_PACKER, test_record)
-        assert output == 'type="test/record" rdtag=None foo="\\\\\\""'
+        assert output.startswith(f'rdtype="test/record" rdtag=None foo="\\\\\\"" {RESERVED_FIELDS_KEY_VALUE_SUFFIX}')
         assert json.loads(output_json) == {
             "event": dict(
                 {
                     "rdtag": None,
-                    "type": "test/record",
+                    "rdtype": "test/record",
                     "foo": '\\"',
                 },
                 **BASE_FIELD_VALUES,
@@ -240,7 +252,14 @@ def test_tcp_protocol():
 
         test_record = test_record_descriptor(foo="bar")
         tcp_writer.write(test_record)
-        mock_socket.return_value.sendall.assert_called_with(b'type="test/record" rdtag=None foo="bar"\n')
+
+        args, _ = mock_socket.return_value.sendall.call_args
+        written_to_splunk = args[0]
+
+        assert written_to_splunk.startswith(
+            b'rdtype="test/record" rdtag=None foo="bar" ' + RESERVED_FIELDS_KEY_VALUE_SUFFIX.encode()
+        )
+        assert written_to_splunk.endswith(b'"\n')
 
 
 def test_https_protocol_records_sourcetype(mock_requests_package: MagicMock):
@@ -282,8 +301,14 @@ def test_https_protocol_records_sourcetype(mock_requests_package: MagicMock):
                 "X-Splunk-Request-Channel": ANY,
             },
             verify=True,
-            data=b'type="test/record" rdtag=None foo="bar"\n',
+            data=ANY,
         )
+        _, kwargs = mock_requests_package.post.call_args
+        sent_data = kwargs["data"]
+        assert sent_data.startswith(
+            b'rdtype="test/record" rdtag=None foo="bar" ' + RESERVED_FIELDS_KEY_VALUE_SUFFIX.encode()
+        )
+        assert sent_data.endswith(b'"\n')
 
 
 def test_https_protocol_json_sourcetype(mock_requests_package: MagicMock):
@@ -322,13 +347,13 @@ def test_https_protocol_json_sourcetype(mock_requests_package: MagicMock):
         )
 
         _, kwargs = mock_requests_package.post.call_args
-        called_with_data = kwargs["data"]
-        first_record_json, _, second_record_json = called_with_data.partition(b"\n")
+        sent_data = kwargs["data"]
+        first_record_json, _, second_record_json = sent_data.partition(b"\n")
         assert json.loads(first_record_json) == {
             "event": dict(
                 {
                     "rdtag": None,
-                    "type": "test/record",
+                    "rdtype": "test/record",
                     "foo": "bar",
                 },
                 **BASE_FIELD_VALUES,
@@ -338,7 +363,7 @@ def test_https_protocol_json_sourcetype(mock_requests_package: MagicMock):
             "event": dict(
                 {
                     "rdtag": None,
-                    "type": "test/record",
+                    "rdtype": "test/record",
                     "foo": "baz",
                 },
                 **BASE_FIELD_VALUES,

--- a/tests/test_splunk_adapter.py
+++ b/tests/test_splunk_adapter.py
@@ -20,7 +20,7 @@ BASE_FIELD_VALUES = {
     "_classification": None,
     "_generated": ANY,
     "_source": None,
-    "_version": 1,
+    # "_version": 1,  # We omit _version as the Splunk adapter has no reader support for serializing the records back
 }
 
 JSON_PACKER = JsonRecordPacker(pack_descriptors=False)


### PR DESCRIPTION
This pull request adds support for the Splunk HTTP Event Collector (HEC) to the Splunk adapter. This is especially useful in scenarios where the already supported TCP Input is not available, for example in Splunk Cloud environments.

Sending data over HTTP Event Collector supports both sending the data in `key=value` format (like the TCP Data Input already uses) and a `json` format. 

Something I'm still unsure of is whether to include the 'builtin' Record Fields such as `_generated`, `_source`, `_classification` and `_version`. Currently, the keyvalue format does _not_ send these fields, but the `json` format does. This difference is caused by the usage of the `JsonRecordPacker` which includes these fields. I don't think it should be inconsistent between the two formats, but what is desired: including or omitting these builtin fields?