### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -38,35 +38,3 @@ jobs:
         with:
           name: coverage
           path: coverage.xml
-  test-windows:
-    runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - python-version: "3.9"
-            python-include: "python3.9"
-            tox-env: "py39"
-            allow_failure: false
-          - python-version: "3.10"
-            python-include: "python3.10"
-            tox-env: "py310"
-            allow_failure: false
-          - python-version: "3.11"
-            python-include: "python3.11"
-            tox-env: "py311"
-            allow_failure: true
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          lfs: true
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-          cache-dependency-path: "pyproject.toml"
-      - run: pip install "tox==4.2.4"
-      - env:
-          C_INCLUDE_PATH: ${{ env.pythonLocation }}/include/${{ matrix.python-include }}
-        run: tox run -e ${{ matrix.tox-env }}

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -2,16 +2,12 @@ name: Python Compatibility
 on: [push, pull_request, workflow_dispatch]
 
 jobs: 
-  test-py37-py38:
+  test-py38:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - python-version: "3.7"
-            python-include: "python3.7"
-            tox-env: "py37"
-            allow_failure: false
           - python-version: "3.8"
             python-include: "python3.8"
             tox-env: "py38"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "flow.record"
 description = "A library for defining and creating structured data (called records) that can be streamed to disk or piped to other tools that use flow.record"
 readme = "README.md"
-requires-python = "~=3.7"
+requires-python = "~=3.8"
 license.text = "Affero General Public License v3"
 authors = [
   {name = "Dissect Team", email = "dissect@fox-it.com"}

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ deps =
     vermin
 commands =
     flake8 flow tests
-    vermin -t=3.7- --no-tips --lint --exclude zoneinfo flow tests
+    vermin -t=3.8- --no-tips --lint --exclude zoneinfo flow tests
 
 [flake8]
 max-line-length = 120

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
 extras = test
 commands =
 # Capturing output will fail on pypy, possibly due to this issue: https://github.com/pytest-dev/pytest/issues/5502
-    pytest {posargs:--color=yes --capture=no --cov=flow --cov-report=term-missing -v tests}
+    pytest --basetemp="{envtmpdir}" {posargs:--color=yes --capture=no --cov=flow --cov-report=term-missing -v tests}
     coverage report
     coverage xml
 


### PR DESCRIPTION
Python 3.7 is EOL since 27 June 2023.
Minimal supported Python version for flow.record is now 3.8.