### PR TITLE
Update `elastic.py` adapter

### DIFF
--- a/flow/record/adapter/elastic.py
+++ b/flow/record/adapter/elastic.py
@@ -73,6 +73,9 @@ class ElasticWriter(AbstractWriter):
         dunder_keys = [key for key in rdict if key.startswith("_")]
         for key in dunder_keys:
             rdict_meta[key.lstrip("_")] = rdict.pop(key)
+        # remove _generated field from metadata to ensure determinstic documents
+        if self.hash_record:
+            rdict_meta.pop("generated", None)
         rdict["_record_metadata"] = rdict_meta
 
         document = {

--- a/flow/record/adapter/elastic.py
+++ b/flow/record/adapter/elastic.py
@@ -1,7 +1,7 @@
+import hashlib
 import logging
 import queue
 import threading
-import hashlib
 from typing import Iterator, Union
 
 import elasticsearch
@@ -55,6 +55,7 @@ class ElasticWriter(AbstractWriter):
         if not verify_certs:
             # Disable InsecureRequestWarning of urllib3, caused by the verify_certs flag.
             import urllib3
+
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     def record_to_document(self, record: Record, index: str) -> dict:
@@ -79,10 +80,6 @@ class ElasticWriter(AbstractWriter):
             "_source": self.json_packer.pack(rdict),
         }
 
-        # Check if hash_record is set and hash record to md5 if flag is set.
-        # Note: the _record_metadata contains timestamp field of target-query output.
-        # An option to change this is to call the `self.json_packer.pack` again on the
-        # `record._asdict()` row.
         if self.hash_record:
             document["_id"] = hashlib.md5(document["_source"].encode()).hexdigest()
 
@@ -141,6 +138,7 @@ class ElasticReader(AbstractReader):
         if not verify_certs:
             # Disable InsecureRequestWarning of urllib3, caused by the verify_certs flag.
             import urllib3
+
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     def __iter__(self) -> Iterator[Record]:


### PR DESCRIPTION
Update `elastic.py` adapter, fix AttributeError if invalid uri is given, add `verify_certs` flag to optional arguments.
Also check with `hasattr` if 'self.es' is set. This can be None, for example if invalid uri (such as missing port number) is given.