### PR TITLE
Fix RecordReader not reading from stdin by default

### DIFF
--- a/flow/record/base.py
+++ b/flow/record/base.py
@@ -801,7 +801,7 @@ def RecordAdapter(
         if sub_adapter:
             cls_url = sub_adapter + "://" + cls_url
     if out is False:
-        if url in ("-", "", None):
+        if url in ("-", "", None) and fileobj is None:
             # For reading stdin, we cannot rely on an extension to know what sort of stream is incoming. Thus, we will
             # treat it as a 'fileobj', where we can peek into the stream and try to select the appropriate adapter.
             fileobj = getattr(sys.stdin, "buffer", sys.stdin)

--- a/flow/record/base.py
+++ b/flow/record/base.py
@@ -801,7 +801,7 @@ def RecordAdapter(
         if sub_adapter:
             cls_url = sub_adapter + "://" + cls_url
     if out is False:
-        if url in ("-", ""):
+        if url in ("-", "", None):
             # For reading stdin, we cannot rely on an extension to know what sort of stream is incoming. Thus, we will
             # treat it as a 'fileobj', where we can peek into the stream and try to select the appropriate adapter.
             fileobj = getattr(sys.stdin, "buffer", sys.stdin)


### PR DESCRIPTION
Calling RecordReader without arguments should always default to stdin