### PR TITLE
Refactor and improve CSV adapter

### DIFF
--- a/flow/record/base.py
+++ b/flow/record/base.py
@@ -982,9 +982,9 @@ def normalize_fieldname(field_name: str) -> str:
         >>> normalize_fieldname("my-variable-name-with-dashes")
         'my_variable_name_with_dashes'
         >>> normalize_fieldname("_my_name_starting_with_underscore")
-        'n__my_name_starting_with_underscore'
+        'x__my_name_starting_with_underscore'
         >>> normalize_fieldname("1337")
-        'n_1337'
+        'x_1337'
         >>> normalize_fieldname("my name with spaces")
         'my_name_with_spaces'
         >>> normalize_fieldname("my name (with) parentheses")
@@ -997,7 +997,7 @@ def normalize_fieldname(field_name: str) -> str:
         field_name = re.sub(r"[- ()]", "_", field_name)
         # prepend `n_` if field_name is empty or starts with underscore or digit
         if len(field_name) == 0 or field_name.startswith("_") or field_name[0].isdecimal():
-            field_name = "n_" + field_name
+            field_name = "x_" + field_name
     return field_name
 
 

--- a/flow/record/base.py
+++ b/flow/record/base.py
@@ -971,6 +971,36 @@ def extend_record(
     return ExtendedRecord.init_from_dict(collections.ChainMap(*kv_maps))
 
 
+@functools.lru_cache(maxsize=4096)
+def normalize_fieldname(field_name: str) -> str:
+    """Returns a normalized version of ``field_name``.
+
+    Some (field) names are not allowed in flow.record, while they can be allowed in other formats.
+    This normalizes the name so it can still be used in flow.record.
+    Reserved field_names are not normalized.
+
+        >>> normalize_fieldname("my-variable-name-with-dashes")
+        'my_variable_name_with_dashes'
+        >>> normalize_fieldname("_my_name_starting_with_underscore")
+        'n__my_name_starting_with_underscore'
+        >>> normalize_fieldname("1337")
+        'n_1337'
+        >>> normalize_fieldname("my name with spaces")
+        'my_name_with_spaces'
+        >>> normalize_fieldname("my name (with) parentheses")
+        'my_name__with__parentheses'
+        >>> normalize_fieldname("_generated")
+        '_generated'
+    """
+
+    if field_name not in RESERVED_FIELDS:
+        field_name = re.sub(r"[- ()]", "_", field_name)
+        # prepend `n_` if field_name is empty or starts with underscore or digit
+        if len(field_name) == 0 or field_name.startswith("_") or field_name[0].isdecimal():
+            field_name = "n_" + field_name
+    return field_name
+
+
 class DynamicFieldtypeModule:
     def __init__(self, path=""):
         self.path = path

--- a/tests/test_csv_adapter.py
+++ b/tests/test_csv_adapter.py
@@ -1,0 +1,75 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from flow.record import RecordReader
+
+
+@pytest.mark.parametrize("delimiter", [",", ";", "\t", "|"])
+def test_csv_sniff(tmp_path: Path, delimiter: str) -> None:
+    """Test CSV adapter with sniffing the dialect."""
+    input_data = delimiter.join(["title", "year", "imdb"]) + "\n"
+    input_data += delimiter.join(["The Shawshank Redemption", "1994", "tt0111161"]) + "\n"
+    input_data += delimiter.join(["The Matrix", "1998", "tt0133093"]) + "\n"
+
+    csv_path = tmp_path / "test.csv"
+    csv_path.write_text(input_data)
+
+    with RecordReader(csv_path) as reader:
+        records = list(reader)
+        assert len(records) == 2
+
+        assert records[0].title == "The Shawshank Redemption"
+        assert records[0].year == "1994"
+        assert records[0].imdb == "tt0111161"
+
+        assert records[1].title == "The Matrix"
+        assert records[1].year == "1998"
+        assert records[1].imdb == "tt0133093"
+
+
+def test_csv_non_standard_headers(tmp_path: Path) -> None:
+    """Test CSV adapter with header names that need to be cleaned up."""
+    input_data = "Filename,Full Path,Size (bytes)\n"
+    input_data += "passwd,/etc/passwd,2370\n"
+    input_data += "shadow,/etc/shadow,1290\n"
+
+    csv_path = tmp_path / "test.csv"
+    csv_path.write_text(input_data)
+
+    with RecordReader(csv_path) as reader:
+        records = list(reader)
+        assert len(records) == 2
+
+        assert records[0].Filename == "passwd"
+        assert records[0].Full_Path == "/etc/passwd"
+        assert records[0].Size__bytes_ == "2370"
+
+        assert records[1].Filename == "shadow"
+        assert records[1].Full_Path == "/etc/shadow"
+        assert records[1].Size__bytes_ == "1290"
+
+
+def test_csv_read_reserved_fields(tmp_path: Path) -> None:
+    """Test CSV adapter with reading reserved field names."""
+    input_data = "_generated,_source,foo,bar\n"
+    input_data += "2023-11-11 11:11:11.111111+11:11,single,hello,world\n"
+    input_data += "2023-11-14T22:13:20+00:00,epoch,goodbye,planet\n"
+
+    csv_path = tmp_path / "test.csv"
+    csv_path.write_text(input_data)
+
+    with RecordReader(csv_path) as reader:
+        records = list(reader)
+        assert len(records) == 2
+
+        assert records[0]._generated == datetime.fromisoformat("2023-11-11 11:11:11.111111+11:11")
+        assert records[0]._source == "single"
+        assert records[0].foo == "hello"
+        assert records[0].bar == "world"
+
+        assert records[1]._generated == datetime.fromtimestamp(1700000000, tz=timezone.utc)
+        assert records[1]._source == "epoch"
+        assert records[1].foo == "goodbye"
+        assert records[1].bar == "planet"

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -15,7 +15,7 @@ from flow.record import (
     fieldtypes,
     record_stream,
 )
-from flow.record.base import merge_record_descriptors
+from flow.record.base import merge_record_descriptors, normalize_fieldname
 from flow.record.exceptions import RecordDescriptorError
 from flow.record.stream import RecordFieldRewriter
 
@@ -781,3 +781,14 @@ def test_merge_record_descriptor_name():
     assert MergedRecord.name == "test/ip_record"
     record = MergedRecord()
     assert record._desc.name == "test/ip_record"
+
+
+def test_clean_fieldname():
+    assert normalize_fieldname("hello") == "hello"
+    assert normalize_fieldname("my-variable-name-with-dashes") == "my_variable_name_with_dashes"
+    assert normalize_fieldname("_my_name_starting_with_underscore") == "n__my_name_starting_with_underscore"
+    assert normalize_fieldname("1337") == "n_1337"
+    assert normalize_fieldname("my name with spaces") == "my_name_with_spaces"
+    assert normalize_fieldname("my name (with) parentheses") == "my_name__with__parentheses"
+    assert normalize_fieldname("_generated") == "_generated"
+    assert normalize_fieldname("_source") == "_source"

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -783,11 +783,11 @@ def test_merge_record_descriptor_name():
     assert record._desc.name == "test/ip_record"
 
 
-def test_clean_fieldname():
+def test_normalize_fieldname():
     assert normalize_fieldname("hello") == "hello"
     assert normalize_fieldname("my-variable-name-with-dashes") == "my_variable_name_with_dashes"
-    assert normalize_fieldname("_my_name_starting_with_underscore") == "n__my_name_starting_with_underscore"
-    assert normalize_fieldname("1337") == "n_1337"
+    assert normalize_fieldname("_my_name_starting_with_underscore") == "x__my_name_starting_with_underscore"
+    assert normalize_fieldname("1337") == "x_1337"
     assert normalize_fieldname("my name with spaces") == "my_name_with_spaces"
     assert normalize_fieldname("my name (with) parentheses") == "my_name__with__parentheses"
     assert normalize_fieldname("_generated") == "_generated"

--- a/tests/test_sqlite_adapter.py
+++ b/tests/test_sqlite_adapter.py
@@ -6,7 +6,8 @@ from typing import Any, Iterator
 import pytest
 
 from flow.record import Record, RecordDescriptor, RecordReader, RecordWriter
-from flow.record.adapter.sqlite import prepare_insert_sql, sanitized_name
+from flow.record.adapter.sqlite import prepare_insert_sql
+from flow.record.base import normalize_fieldname
 from flow.record.exceptions import RecordDescriptorError
 
 
@@ -78,7 +79,7 @@ def test_field_name_sanitization(tmp_path: Path, field_name: str) -> None:
     con.close()
 
     data_records = []
-    sanitized_field_name = sanitized_name(field_name)
+    sanitized_field_name = normalize_fieldname(field_name)
 
     with RecordReader(f"sqlite://{db}") as reader:
         data_records = [(getattr(record, sanitized_field_name),) for record in reader]


### PR DESCRIPTION
This change allows the CSV adapter to:
 - properly read reserved field names (eg: _generated, _source, etc)
 - use `clean_fieldname` that otherwise are invalid names in flow.record
 - deduce format of csv file automatically by using `csv.Sniffer`