### PR TITLE
Use reprlib to limit the warning message

### DIFF
--- a/flow/record/stream.py
+++ b/flow/record/stream.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import datetime
 import logging
 import os
+import reprlib
 import struct
 import sys
 from collections import ChainMap
@@ -16,6 +17,9 @@ from .base import RecordDescriptor, RecordReader
 from .packer import RecordPacker
 
 log = logging.getLogger(__package__)
+
+aRepr = reprlib.Repr()
+aRepr.maxother = 100
 
 
 def RecordOutput(fp):
@@ -156,7 +160,7 @@ def record_stream(sources, selector=None):
         except KeyboardInterrupt:
             raise
         except Exception as e:  # noqa: B902
-            log.warning("Exception in {!r} for {!r}: {!r} -- skipping to next reader".format(reader, src, e))
+            log.warning("Exception in %r for %r: %s -- skipping to next reader", reader, src, aRepr.repr(e))
             continue
 
 

--- a/flow/record/stream.py
+++ b/flow/record/stream.py
@@ -19,7 +19,7 @@ from .packer import RecordPacker
 log = logging.getLogger(__package__)
 
 aRepr = reprlib.Repr()
-aRepr.maxother = 100
+aRepr.maxother = 255
 
 
 def RecordOutput(fp):


### PR DESCRIPTION
The warning message could get very long (single line) due to extra data in msgpack parsing. For example due to corrupt file, or incorrect use.

By using reprlib we limit the length of the warning message.