### PR TITLE
Add -Lv/--line-verbose mode to rdump

### DIFF
--- a/flow/record/adapter/line.py
+++ b/flow/record/adapter/line.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import lru_cache
 
 from flow.record import RecordDescriptor, open_path_or_stream

--- a/flow/record/base.py
+++ b/flow/record/base.py
@@ -499,7 +499,7 @@ class RecordDescriptor:
             "_source": RecordField("_source", "string"),
             "_classification": RecordField("_classification", "datetime"),
             "_generated": RecordField("_generated", "datetime"),
-            "_version": RecordField("_version", "vaeint"),
+            "_version": RecordField("_version", "varint"),
         }
 
         Returns:

--- a/flow/record/tools/rdump.py
+++ b/flow/record/tools/rdump.py
@@ -98,7 +98,9 @@ def main(argv=None):
     output.add_argument("-c", "--count", type=int, help="Exit after COUNT records")
     output.add_argument("--skip", metavar="COUNT", type=int, default=0, help="Skip the first COUNT records")
     output.add_argument("-w", "--writer", metavar="OUTPUT", default=None, help="Write records to output")
-    output.add_argument("-m", "--mode", default=None, choices=("csv", "json", "jsonlines", "line"), help="Output mode")
+    output.add_argument(
+        "-m", "--mode", default=None, choices=("csv", "json", "jsonlines", "line", "line-verbose"), help="Output mode"
+    )
     output.add_argument(
         "--split", metavar="COUNT", default=None, type=int, help="Write record files smaller than COUNT records"
     )
@@ -155,6 +157,15 @@ def main(argv=None):
         default=argparse.SUPPRESS,
         help="Short for --mode=line",
     )
+    aliases.add_argument(
+        "-Lv",
+        "--line-verbose",
+        action="store_const",
+        const="line-verbose",
+        dest="mode",
+        default=argparse.SUPPRESS,
+        help="Short for --mode=line-verbose",
+    )
 
     args = parser.parse_args(argv)
 
@@ -176,6 +187,7 @@ def main(argv=None):
             "json": "jsonfile://?indent=2&descriptors=false",
             "jsonlines": "jsonfile://?descriptors=false",
             "line": "line://",
+            "line-verbose": "line://?verbose=true",
         }
         uri = mode_to_uri.get(args.mode, uri)
         qparams = {

--- a/tests/test_rdump.py
+++ b/tests/test_rdump.py
@@ -624,3 +624,39 @@ def test_flow_record_invalid_tz(tmp_path, capsys):
 
     # restore DISPLAY_TZINFO just in case
     flow.record.fieldtypes.DISPLAY_TZINFO = flow_record_tz(default_tz="UTC")
+
+
+@pytest.mark.parametrize(
+    "rdump_params",
+    [
+        ["--mode=line-verbose"],
+        ["--line-verbose"],
+        ["-Lv"],
+        ["-w line://?verbose=true"],
+        ["-w line://?verbose=1"],
+        ["-w line://?verbose=True"],
+    ],
+)
+def test_rdump_line_verbose(tmp_path, capsys, rdump_params):
+    TestRecord = RecordDescriptor(
+        "test/rdump/line_verbose",
+        [
+            ("datetime", "stamp"),
+            ("bytes", "data"),
+            ("uint32", "counter"),
+            ("string", "foo"),
+        ],
+    )
+    record_path = tmp_path / "test.records"
+
+    with RecordWriter(record_path) as writer:
+        writer.write(TestRecord())
+
+    rdump.main([str(record_path)] + rdump_params)
+    captured = capsys.readouterr()
+
+    assert captured.err == ""
+    assert "stamp (datetime) =" in captured.out
+    assert "data (bytes) =" in captured.out
+    assert "counter (uint32) =" in captured.out
+    assert "foo (string) =" in captured.out

--- a/tests/test_rdump.py
+++ b/tests/test_rdump.py
@@ -632,9 +632,9 @@ def test_flow_record_invalid_tz(tmp_path, capsys):
         ["--mode=line-verbose"],
         ["--line-verbose"],
         ["-Lv"],
-        ["-w line://?verbose=true"],
-        ["-w line://?verbose=1"],
-        ["-w line://?verbose=True"],
+        ["-w", "line://?verbose=true"],
+        ["-w", "line://?verbose=1"],
+        ["-w", "line://?verbose=True"],
     ],
 )
 def test_rdump_line_verbose(tmp_path, capsys, rdump_params):


### PR DESCRIPTION
This adds a verbose option to the LineWriter adapter which also prints the field type.