### PR TITLE
Add AttributeError to except ImportError statements

### DIFF
--- a/flow/record/base.py
+++ b/flow/record/base.py
@@ -25,26 +25,26 @@ try:
     import lz4.frame as lz4
 
     HAS_LZ4 = True
-except ImportError:
+except (AttributeError, ImportError):
     HAS_LZ4 = False
 try:
     import bz2
 
     HAS_BZ2 = True
-except ImportError:
+except (AttributeError, ImportError):
     HAS_BZ2 = False
 try:
     import zstandard as zstd
 
     HAS_ZSTD = True
-except ImportError:
+except (AttributeError, ImportError):
     HAS_ZSTD = False
 
 try:
     import fastavro as avro  # noqa
 
     HAS_AVRO = True
-except ImportError:
+except (AttributeError, ImportError):
     HAS_AVRO = False
 
 from collections import OrderedDict

--- a/flow/record/fieldtypes/__init__.py
+++ b/flow/record/fieldtypes/__init__.py
@@ -17,10 +17,10 @@ from urllib.parse import urlparse
 try:
     try:
         from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
-    except ImportError:
+    except (AttributeError, ImportError):
         from backports.zoneinfo import ZoneInfo, ZoneInfoNotFoundError
     HAS_ZONE_INFO = True
-except ImportError:
+except (AttributeError, ImportError):
     HAS_ZONE_INFO = False
 
 

--- a/flow/record/selector.py
+++ b/flow/record/selector.py
@@ -12,7 +12,7 @@ try:
     import astor
 
     HAVE_ASTOR = True
-except ImportError:
+except (AttributeError, ImportError):
     HAVE_ASTOR = False
 
 string_types = (str, type(""))

--- a/flow/record/tools/rdump.py
+++ b/flow/record/tools/rdump.py
@@ -18,7 +18,7 @@ from flow.record.utils import catch_sigpipe
 
 try:
     from flow.record.version import version
-except ImportError:
+except (AttributeError, ImportError):
     version = "unknown"
 
 log = logging.getLogger(__name__)
@@ -51,7 +51,7 @@ def list_adapters():
             mod = import_module(f"flow.record.adapter.{adapter}")
             usage = indent(mod.__usage__.strip(), prefix="    ")
             print(f"  {adapter}:\n{usage}\n")
-        except ImportError as reason:
+        except (AttributeError, ImportError) as reason:
             failed.append((adapter, reason))
 
     if failed:


### PR DESCRIPTION
In some cases windows throws an AttributeError instead of an ImportError during an import