### PR TITLE
Move lru_cache definitions to __init__

### DIFF
--- a/flow/record/stream.py
+++ b/flow/record/stream.py
@@ -256,7 +256,7 @@ class RecordFieldRewriter:
         self.exclude = exclude or []
         self.expression = compile(expression, "<string>", "exec") if expression else None
 
-        self.record_descriptor_for_fields = lru_cache(maxsize=256)(self.record_descriptor_for_fields)
+        self.record_descriptor_for_fields = lru_cache(256)(self.record_descriptor_for_fields)
 
     def record_descriptor_for_fields(self, descriptor, fields=None, exclude=None, new_fields=None):
         if not fields and not exclude and not new_fields:

--- a/flow/record/stream.py
+++ b/flow/record/stream.py
@@ -256,7 +256,8 @@ class RecordFieldRewriter:
         self.exclude = exclude or []
         self.expression = compile(expression, "<string>", "exec") if expression else None
 
-    @lru_cache(maxsize=256)
+        self.record_descriptor_for_fields = lru_cache(maxsize=256)(self.record_descriptor_for_fields)
+
     def record_descriptor_for_fields(self, descriptor, fields=None, exclude=None, new_fields=None):
         if not fields and not exclude and not new_fields:
             return descriptor


### PR DESCRIPTION
Using the lru_cache decorators on class methods, the ones that have a reference to `self`,
will also cache self. So we move it to the __init__ of the class
    
(DIS-2913)