### PR TITLE
Fix hashing of records with list fieldtypes

### DIFF
--- a/flow/record/base.py
+++ b/flow/record/base.py
@@ -215,7 +215,7 @@ class Record:
             for list_value in value:
                 if isinstance(list_value, dict):
                     # List values that are dicts must be converted to tuples
-                    dict_as_tuple = ((k, v) for k, v in list_value.items())
+                    dict_as_tuple = tuple(list_value.items())
                     list_values.append(dict_as_tuple)
                 else:
                     list_values.append(list_value)

--- a/flow/record/base.py
+++ b/flow/record/base.py
@@ -201,7 +201,27 @@ class Record:
         return result
 
     def __hash__(self) -> int:
-        return hash(self._pack(excluded_fields=IGNORE_FIELDS_FOR_COMPARISON))
+        desc_identifier, values = self._pack(excluded_fields=IGNORE_FIELDS_FOR_COMPARISON)
+        if not any((isinstance(value, list) for value in values)):
+            return hash((desc_identifier, values))
+
+        # Lists have to be converted to tuples to be able to hash them
+        record_values = []
+        for value in values:
+            if not isinstance(value, list):
+                record_values.append(value)
+                continue
+            list_values = []
+            for list_value in value:
+                if isinstance(list_value, dict):
+                    # List values that are dicts must be converted to tuples
+                    dict_as_tuple = ((k, v) for k, v in list_value.items())
+                    list_values.append(dict_as_tuple)
+                else:
+                    list_values.append(list_value)
+            record_values.append(tuple(list_values))
+
+        return hash((desc_identifier, tuple(record_values)))
 
     def __repr__(self):
         return "<{} {}>".format(

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -922,3 +922,16 @@ def test_ignore_fields_for_comparision_contextmanager():
     # test reset again
     assert len(set(records)) == len(records)
     assert records[0] != records[1]
+
+
+def test_list_field_type_hashing():
+    TestRecord = RecordDescriptor(
+        "test/record",
+        [
+            ("string[]", "stringlist"),
+            ("dictlist", "dictlist"),
+        ],
+    )
+
+    test_record = TestRecord(stringlist=["a", "b", "c", "d"], dictlist=[{"a": "b", "c": "d"}])
+    assert isinstance(hash(test_record), int)

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -933,5 +933,5 @@ def test_list_field_type_hashing():
         ],
     )
 
-    test_record = TestRecord(stringlist=["a", "b", "c", "d"], dictlist=[{"a": "b", "c": "d"}])
+    test_record = TestRecord(stringlist=["a", "b", "c", "d"], dictlist=[{"a": "b", "c": "d"}, {"foo": "bar"}])
     assert isinstance(hash(test_record), int)


### PR DESCRIPTION
Currently flow.record breaks when `__hash__` is called on a record that has a list fieldtype. As lists are mutable, they have to be converted into tuples first so they can be hashed.