### PR TITLE
Add metadata fields to elastic adapter

### DIFF
--- a/flow/record/adapter/elastic.py
+++ b/flow/record/adapter/elastic.py
@@ -97,7 +97,8 @@ class ElasticWriter(AbstractWriter):
         if self.hash_record:
             rdict_meta.pop("generated", None)
 
-        rdict["_record_metadata"] = rdict_meta | self.metadata_fields
+        rdict["_record_metadata"] = rdict_meta.copy()
+        rdict["_record_metadata"].update(self.metadata_fields)
 
         document = {
             "_index": index,
@@ -151,7 +152,7 @@ class ElasticReader(AbstractReader):
         verify_certs: Union[str, bool] = True,
         http_compress: Union[str, bool] = True,
         selector: Union[None, Selector, CompiledSelector] = None,
-        api_key: Union[str, bool] = False,
+        api_key: Union[str] = None,
         **kwargs,
     ) -> None:
         self.index = index

--- a/flow/record/adapter/elastic.py
+++ b/flow/record/adapter/elastic.py
@@ -2,7 +2,7 @@ import hashlib
 import logging
 import queue
 import threading
-from typing import Iterator, Union
+from typing import Iterator, Optional, Union
 
 import elasticsearch
 import elasticsearch.helpers
@@ -40,7 +40,7 @@ class ElasticWriter(AbstractWriter):
         verify_certs: Union[str, bool] = True,
         http_compress: Union[str, bool] = True,
         hash_record: Union[str, bool] = False,
-        api_key: Union[str, bool] = False,
+        api_key: Optional[str] = None,
         **kwargs,
     ) -> None:
         self.index = index
@@ -152,7 +152,7 @@ class ElasticReader(AbstractReader):
         verify_certs: Union[str, bool] = True,
         http_compress: Union[str, bool] = True,
         selector: Union[None, Selector, CompiledSelector] = None,
-        api_key: Union[str] = None,
+        api_key: Optional[str] = None,
         **kwargs,
     ) -> None:
         self.index = index

--- a/flow/record/adapter/elastic.py
+++ b/flow/record/adapter/elastic.py
@@ -49,7 +49,7 @@ class ElasticWriter(AbstractWriter):
         http_compress = str(http_compress).lower() in ("1", "true")
         self.hash_record = str(hash_record).lower() in ("1", "true")
 
-        if not uri.startswith("https://") and not uri.startswith("http://"):
+        if not uri.lower().startswith(("http://", "https://")):
             uri = "http://" + uri
 
         self.es = elasticsearch.Elasticsearch(
@@ -161,7 +161,7 @@ class ElasticReader(AbstractReader):
         verify_certs = str(verify_certs).lower() in ("1", "true")
         http_compress = str(http_compress).lower() in ("1", "true")
 
-        if not uri.startswith("http"):
+        if not uri.lower().startswith(("http://", "https://")):
             uri = "http://" + uri
 
         self.es = elasticsearch.Elasticsearch(

--- a/flow/record/adapter/elastic.py
+++ b/flow/record/adapter/elastic.py
@@ -22,6 +22,7 @@ Read usage: rdump elastic+[PROTOCOL]://[IP]:[PORT]?index=[INDEX]
 [PROTOCOL]: http or https. Defaults to https when "+[PROTOCOL]" is omitted
 
 Optional arguments:
+  [API_KEY]: base64 encoded api key to authenticate with (default: False)
   [INDEX]: name of the index to use (default: records)
   [VERIFY_CERTS]: verify certs of Elasticsearch instance (default: True)
   [HASH_RECORD]: make record unique by hashing record [slow] (default: False)
@@ -39,6 +40,7 @@ class ElasticWriter(AbstractWriter):
         verify_certs: Union[str, bool] = True,
         http_compress: Union[str, bool] = True,
         hash_record: Union[str, bool] = False,
+        api_key: Union[str, bool] = False,
         **kwargs,
     ) -> None:
         self.index = index
@@ -54,6 +56,7 @@ class ElasticWriter(AbstractWriter):
             uri,
             verify_certs=verify_certs,
             http_compress=http_compress,
+            api_key=api_key,
         )
 
         self.json_packer = JsonRecordPacker()
@@ -148,6 +151,7 @@ class ElasticReader(AbstractReader):
         verify_certs: Union[str, bool] = True,
         http_compress: Union[str, bool] = True,
         selector: Union[None, Selector, CompiledSelector] = None,
+        api_key: Union[str, bool] = False,
         **kwargs,
     ) -> None:
         self.index = index
@@ -163,6 +167,7 @@ class ElasticReader(AbstractReader):
             uri,
             verify_certs=verify_certs,
             http_compress=http_compress,
+            api_key=api_key,
         )
 
         if not verify_certs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ splunk = [
 test = [
     "flow.record[compression]",
     "flow.record[avro]",
+    "flow.record[elastic]",
     "duckdb; platform_python_implementation != 'PyPy' and python_version < '3.12'", # duckdb
     "pytz; platform_python_implementation != 'PyPy' and python_version < '3.12'", # duckdb
 ]

--- a/tests/test_elastic_adapter.py
+++ b/tests/test_elastic_adapter.py
@@ -1,0 +1,53 @@
+import json
+
+import pytest
+
+from flow.record import RecordDescriptor
+from flow.record.adapter.elastic import ElasticWriter
+
+MyRecord = RecordDescriptor(
+    "my/record",
+    [
+        ("string", "field_one"),
+        ("string", "field_two"),
+    ],
+)
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        MyRecord("first", "record"),
+        MyRecord("second", "record"),
+    ],
+)
+def test_elastic_writer_metadata(record):
+    options = {
+        "_meta_foo": "some value",
+        "_meta_bar": "another value",
+    }
+
+    with ElasticWriter(uri="elasticsearch:9200", **options) as writer:
+        assert writer.metadata_fields == {"foo": "some value", "bar": "another value"}
+
+        assert writer.record_to_document(record, "some-index") == {
+            "_index": "some-index",
+            "_source": json.dumps(
+                {
+                    "field_one": record.field_one,
+                    "field_two": record.field_two,
+                    "_record_metadata": {
+                        "descriptor": {
+                            "name": "my/record",
+                            "hash": record._desc.descriptor_hash,
+                        },
+                        "source": None,
+                        "classification": None,
+                        "generated": record._generated.isoformat(),
+                        "version": 1,
+                        "foo": "some value",
+                        "bar": "another value",
+                    },
+                }
+            ),
+        }


### PR DESCRIPTION
This PR adds metadata fields to the elastic adapter and repairs `elastic+[PROTOCOL]://` behaviour. It also enables users to authenticate to Elasticsearch with an API key.

You can now write arbitrary metadata to the `document._source._record_metadata` dict using the following syntax:
```
rdump -w "elastic+https://localhost:9200?_meta_foo=bar"
```

This will result in the following `_record_metadata` dict:

```
{
    ...
    "foo": "bar"
}
```

Of course we can change `_meta_` to something else if that seems more appropriate for the flow.record project.