### PR TITLE
Add support for empty value in path fieldtype

### DIFF
--- a/flow/record/fieldtypes/__init__.py
+++ b/flow/record/fieldtypes/__init__.py
@@ -686,10 +686,22 @@ class path(pathlib.PurePath, FieldType):
             obj = cls._from_parts(args)
         return obj
 
+    def __init__(self, *args):
+        self._empty_path = False
+        if not args or args == ("",):
+            self._empty_path = True
+
     def __eq__(self, other: Any) -> bool:
+        if self._empty_path:
+            return other == ""
         if isinstance(other, str):
             return str(self) == other or self == self.__class__(other)
         return super().__eq__(other)
+
+    def __str__(self) -> str:
+        if self._empty_path:
+            return ""
+        return super().__str__()
 
     def __repr__(self) -> str:
         return repr(str(self))

--- a/flow/record/fieldtypes/__init__.py
+++ b/flow/record/fieldtypes/__init__.py
@@ -691,10 +691,10 @@ class path(pathlib.PurePath, FieldType):
         return obj
 
     def __eq__(self, other: Any) -> bool:
-        if self._empty_path:
-            return other == ""
         if isinstance(other, str):
             return str(self) == other or self == self.__class__(other)
+        if self._empty_path:
+            return isinstance(other, self.__class__) and other._empty_path
         return super().__eq__(other)
 
     def __str__(self) -> str:

--- a/flow/record/fieldtypes/__init__.py
+++ b/flow/record/fieldtypes/__init__.py
@@ -687,6 +687,7 @@ class path(pathlib.PurePath, FieldType):
         return obj
 
     def __init__(self, *args):
+        super().__init__(*args)
         self._empty_path = False
         if not args or args == ("",):
             self._empty_path = True

--- a/flow/record/fieldtypes/__init__.py
+++ b/flow/record/fieldtypes/__init__.py
@@ -663,7 +663,7 @@ class path(pathlib.PurePath, FieldType):
                         #
                         # This construction works around that by converting all path parts
                         # to strings first.
-                        args = (str(arg) for arg in args)
+                        args = tuple(str(arg) for arg in args)
                 elif isinstance(path_part, pathlib.PurePosixPath):
                     cls = posix_path
                 elif _is_windowslike_path(path_part):
@@ -671,7 +671,7 @@ class path(pathlib.PurePath, FieldType):
                     # like path separator (\).
                     cls = windows_path
                     if not PY_312:
-                        args = (str(arg) for arg in args)
+                        args = tuple(str(arg) for arg in args)
                 elif _is_posixlike_path(path_part):
                     # This handles any custom PurePath based implementations that don't have a
                     # windows like path separator (\).
@@ -684,13 +684,11 @@ class path(pathlib.PurePath, FieldType):
             obj = super().__new__(cls)
         else:
             obj = cls._from_parts(args)
-        return obj
 
-    def __init__(self, *args):
-        super().__init__(*args)
-        self._empty_path = False
+        obj._empty_path = False
         if not args or args == ("",):
-            self._empty_path = True
+            obj._empty_path = True
+        return obj
 
     def __eq__(self, other: Any) -> bool:
         if self._empty_path:

--- a/tests/test_fieldtypes.py
+++ b/tests/test_fieldtypes.py
@@ -1146,14 +1146,20 @@ def test_empty_path(path_cls) -> None:
     assert p1 == ""
     assert p1._empty_path
     assert str(p1) == ""
+    assert p1 != path_cls(".")
 
     # initialize without any arguments
     p2 = path_cls()
     assert p2 == ""
     assert p2._empty_path
     assert str(p2) == ""
+    assert p2 != path_cls(".")
 
     assert p1 == p2
+
+
+def test_empty_path_different_types() -> None:
+    assert fieldtypes.posix_path("") != fieldtypes.windows_path("")
 
 
 def test_record_empty_path() -> None:


### PR DESCRIPTION
Normally an empty path would be normalized to a "." (dot) character.
This change allows you to initialize a path field with an empty string.
This is useful to represent a path that is empty.

Fixes DIS-2557

<!--
Thank you for submitting a Pull Request. Please:
* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Include a description of the proposed changes and how to test them.

* After creation, associate the PR with an issue, under the development section.
  Or use closing keywords in the body during creation:
  E.G:
  * close(|s|d) #<nr>
  * fix(|es|ed) #<nr>
  * resolve(|s|d) #<nr>
-->
