### PR TITLE
Fix JsonRecordPacker boolean packing

### DIFF
--- a/flow/record/jsonpacker.py
+++ b/flow/record/jsonpacker.py
@@ -51,7 +51,7 @@ class JsonRecordPacker:
                 if field_type == "bytes" and isinstance(serial[field_name], str):
                     serial[field_name] = base64.b64encode(serial[field_name]).decode()
 
-                # Boolean field types should be case to a bool instead of staying ints
+                # Boolean field types should be cast to a bool instead of staying ints
                 elif field_type == "boolean" and isinstance(serial[field_name], int):
                     serial[field_name] = bool(serial[field_name])
 

--- a/flow/record/jsonpacker.py
+++ b/flow/record/jsonpacker.py
@@ -41,14 +41,19 @@ class JsonRecordPacker:
             if obj._desc.identifier not in self.descriptors:
                 self.register(obj._desc, True)
             serial = obj._asdict()
+
             if self.pack_descriptors:
                 serial["_type"] = "record"
                 serial["_recorddescriptor"] = obj._desc.identifier
 
-            # PYTHON2: Because "bytes" are also "str" we have to handle this here
             for field_type, field_name in obj._desc.get_field_tuples():
+                # PYTHON2: Because "bytes" are also "str" we have to handle this here
                 if field_type == "bytes" and isinstance(serial[field_name], str):
                     serial[field_name] = base64.b64encode(serial[field_name]).decode()
+
+                # Boolean field types should be case to a bool instead of staying ints
+                elif field_type == "boolean" and isinstance(serial[field_name], int):
+                    serial[field_name] = bool(serial[field_name])
 
             return serial
         if isinstance(obj, RecordDescriptor):

--- a/tests/test_json_packer.py
+++ b/tests/test_json_packer.py
@@ -81,6 +81,12 @@ def test_record_pack_bool_regression() -> None:
         ],
     )
 
+    record = TestRecord(some_varint=1, some_uint=0, some_boolean=False)
     packer = JsonRecordPacker()
-    data = packer.pack(TestRecord(some_varint=1, some_uint=0, some_boolean=False))
+
+    # pack to json string and check if some_boolean is false instead of 0
+    data = packer.pack(record)
     assert data.startswith('{"some_varint": 1, "some_uint": 0, "some_boolean": false, ')
+
+    # pack the json string back to a record and make sure it is the same as before
+    assert packer.unpack(data) == record

--- a/tests/test_json_packer.py
+++ b/tests/test_json_packer.py
@@ -69,3 +69,18 @@ def test_record_descriptor_not_found():
     packer = JsonRecordPacker()
     with pytest.raises(RecordDescriptorNotFound, match="No RecordDescriptor found for: .*test/descriptor_not_found"):
         packer.unpack(data)
+
+
+def test_record_pack_bool_regression() -> None:
+    TestRecord = RecordDescriptor(
+        "test/record_pack_bool",
+        [
+            ("varint", "some_varint"),
+            ("uint16", "some_uint"),
+            ("boolean", "some_boolean"),
+        ],
+    )
+
+    packer = JsonRecordPacker()
+    data = packer.pack(TestRecord(some_varint=1, some_uint=0, some_boolean=False))
+    assert data.startswith('{"some_varint": 1, "some_uint": 0, "some_boolean": false, ')


### PR DESCRIPTION
This PR fixes `boolean` field type packing behaviour of the `JsonRecordPacker`. Currently record types of `boolean` are not converted to JSON booleans but become integers. This patch fixes that.