### PR TITLE
Fix the record field name validator regex

### DIFF
--- a/flow/record/base.py
+++ b/flow/record/base.py
@@ -89,7 +89,7 @@ AVRO_MAGIC = b"Obj"
 RECORDSTREAM_MAGIC = b"RECORDSTREAM\n"
 RECORDSTREAM_MAGIC_DEPTH = 4 + 2 + len(RECORDSTREAM_MAGIC)
 
-RE_VALID_FIELD_NAME = re.compile(r"^_?[a-zA-Z][a-zA-Z0-9_]*(?:\[\])?$")
+RE_VALID_FIELD_NAME = re.compile(r"^_?[a-zA-Z][a-zA-Z0-9_]*$")
 RE_VALID_RECORD_TYPE_NAME = re.compile("^[a-zA-Z][a-zA-Z0-9_]*(/[a-zA-Z][a-zA-Z0-9_]*)*$")
 
 RECORD_CLASS_TEMPLATE = """

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -316,6 +316,8 @@ def test_mixed_case_name():
     assert is_valid_field_name("Test")
     assert is_valid_field_name("test")
     assert is_valid_field_name("TEST")
+    assert not is_valid_field_name("test[]")
+    assert not is_valid_field_name("_test")
 
     TestRecord = RecordDescriptor(
         "Test/Record",


### PR DESCRIPTION
The original regex allowed a literal "[]" at the end of a name, which breaks using the name as Python identifier.

<!--
Thank you for submitting a Pull Request. Please:
* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Include a description of the proposed changes and how to test them.

* After creation, associate the PR with an issue, under the development section.
  Or use closing keywords in the body during creation:
  E.G:
  * close(|s|d) #<nr>
  * fix(|es|ed) #<nr>
  * resolve(|s|d) #<nr>
-->
