### PR TITLE
Handle NoneType in elastic adapter document_stream

### DIFF
--- a/flow/record/adapter/elastic.py
+++ b/flow/record/adapter/elastic.py
@@ -128,6 +128,8 @@ class ElasticWriter(AbstractWriter):
             record = self.queue.get()
             if record is StopIteration:
                 break
+            if not record:
+                continue
             yield self.record_to_document(record, index=self.index)
 
     def streaming_bulk_thread(self) -> None:


### PR DESCRIPTION
This PR fixes a `Unpackable type <class 'NoneType'>` exception for the elastic adapter. This can occur when the record queue gets populated with `None` instead of a record - which apparently can occur if for example a Dissect plugin does not return any records.
