### PR TITLE
Better exception handling for Elastic adapter

### DIFF
--- a/flow/record/adapter/elastic.py
+++ b/flow/record/adapter/elastic.py
@@ -15,14 +15,6 @@ try:
 except ImportError:
     HAS_ELASTIC = False
 
-try:
-    import tqdm
-
-    HAS_TQDM = True
-
-except ImportError:
-    HAS_TQDM = False
-
 from flow.record.adapter import AbstractReader, AbstractWriter
 from flow.record.base import Record, RecordDescriptor
 from flow.record.fieldtypes import fieldtype_for_value
@@ -119,11 +111,6 @@ class ElasticWriter(AbstractWriter):
             if arg_key.startswith("_meta_"):
                 self.metadata_fields[arg_key[6:]] = arg_val
 
-        if HAS_TQDM:
-            self.progress = tqdm.tqdm(unit=" records", delay=3)
-        else:
-            self.progress = None
-
     def excepthook(self, exc: threading.ExceptHookArgs, *args, **kwargs) -> None:
         log.error("Exception in thread: %s", exc)
         self.exception = getattr(exc, "exc_value", exc)
@@ -189,8 +176,7 @@ class ElasticWriter(AbstractWriter):
             # Some settings have to be redefined because streaming_bulk does not inherit them from the self.es instance.
             max_retries=3,
         ):
-            if HAS_TQDM:
-                self.progress.update(1)
+            pass
 
         self.event.set()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ compression = [
 ]
 elastic = [
     "elasticsearch",
-    "tqdm",
 ]
 geoip = [
     "maxminddb",


### PR DESCRIPTION
This PR fixes two issues with the Elastic adapter. Currently the Elastic adapter fails silently  - as in it does not break but continues - when a record is not inserted in the index. We make sure to raise a `ValueError` instead so the `threading.excepthook` catches the error and stops the elastic writer.

The second issue we fix here is we make sure both reader and writer threads crash when `self.exception` is filled. This prevents a hanging reader thread if the writer thread fails.