### PR TITLE
Suppress csv.Sniffer exception

### DIFF
--- a/flow/record/adapter/csvfile.py
+++ b/flow/record/adapter/csvfile.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import csv
 import sys
 from pathlib import Path
@@ -89,7 +90,8 @@ class CsvfileReader(AbstractReader):
 
         self.dialect = "excel"
         if self.fp.seekable():
-            self.dialect = csv.Sniffer().sniff(self.fp.read(1024))
+            with contextlib.suppress(csv.Error):
+                self.dialect = csv.Sniffer().sniff(self.fp.read(1024))
             self.fp.seek(0)
         self.reader = csv.reader(self.fp, dialect=self.dialect)
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -711,5 +711,15 @@ def test_rdump_selected_fields(capsysbinary: pytest.CaptureFixture) -> None:
     assert captured.out == b"Q42eWSaF,A sample pastebin record,text\r\n"
 
 
+def test_rdump_csv_sniff(tmp_path: Path, capsysbinary: pytest.CaptureFixture) -> None:
+    csv_path = tmp_path / "test.csv"
+    csv_path.write_text("ip,common_name,vulnerable\n127.0.0.1,localhost,1\n192.168.4.20,")
+    rdump.main([str(csv_path)])
+
+    captured = capsysbinary.readouterr()
+    assert b"<csv/reader ip='127.0.0.1' common_name='localhost' vulnerable='1'>" in captured.out
+    assert b"<csv/reader ip='192.168.4.20' common_name='' vulnerable=None>" in captured.out
+
+
 if __name__ == "__main__":
     __import__("standalone_test").main(globals())


### PR DESCRIPTION
Sometimes the CSV Sniffer cannot determine the delimiter and would raise: "Could not determine delimiter"

This PR suppresses this exception so it can still continue parsing the CSV with default settings.

<!--
Thank you for submitting a Pull Request. Please:
* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Include a description of the proposed changes and how to test them.

* After creation, associate the PR with an issue, under the development section.
  Or use closing keywords in the body during creation:
  E.G:
  * close(|s|d) #<nr>
  * fix(|es|ed) #<nr>
  * resolve(|s|d) #<nr>
-->
