### PR TITLE
Add record descriptor name to Elastic writer exception message

### DIFF
--- a/tests/test_elastic_adapter.py
+++ b/tests/test_elastic_adapter.py
@@ -4,6 +4,7 @@ import json
 from typing import TYPE_CHECKING
 
 import pytest
+from elasticsearch.helpers import BulkIndexError
 
 from flow.record import RecordDescriptor
 from flow.record.adapter.elastic import ElasticWriter
@@ -57,3 +58,47 @@ def test_elastic_writer_metadata(record: Record) -> None:
                 }
             ),
         }
+
+
+def test_elastic_writer_metadata_exception() -> None:
+    with ElasticWriter(uri="elasticsearch:9200") as writer:
+        writer.excepthook(
+            BulkIndexError(
+                "1 document(s) failed to index.",
+                errors=[
+                    {
+                        "index": {
+                            "_index": "example-index",
+                            "_id": "bWFkZSB5b3UgbG9vayDwn5GA",
+                            "status": 400,
+                            "error": {
+                                "type": "document_parsing_exception",
+                                "reason": "[1:225] failed to parse field [example] of type [long] in document with id "
+                                "'bWFkZSB5b3UgbG9vayDwn5GA'. Preview of field's value: 'Foo'",
+                                "caused_by": {
+                                    "type": "illegal_argument_exception",
+                                    "reason": 'For input string: "Foo"',
+                                },
+                            },
+                            "data": '{"example":"Foo","_record_metadata":{"descriptor":{"name":"example/record",'
+                            '"hash":1234567890},"source":"/path/to/source","classification":null,'
+                            '"generated":"2025-12-31T12:34:56.789012+00:00","version":1}}',
+                        }
+                    }
+                ],
+            )
+        )
+
+        assert writer.exception.args == (
+            (
+                "1 document(s) failed to index. (example/record: 400 "
+                "document_parsing_exception [1:225] failed to parse field "
+                "[example] of type [long] in document with id 'bWFkZSB5b3UgbG9vayDwn5GA'. "
+                "Preview of field's value: 'Foo')"
+            ),
+        )
+
+        with pytest.raises(BulkIndexError):
+            writer.__exit__()
+
+        writer.exception = None


### PR DESCRIPTION
This PR improves the exception message thrown when the Elastic adapter attempts to write documents that get rejected by the remote Elasticsearch server.