### PR TITLE
Add Apache Parquet Adapter

### DIFF
--- a/flow/record/adapter/arrow.py
+++ b/flow/record/adapter/arrow.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import contextlib
+import logging
+from typing import TYPE_CHECKING, BinaryIO, Literal
+
+import pyarrow as pa
+
+from flow.record import Record, RecordDescriptor, open_path_or_stream
+from flow.record.adapter import AbstractReader, AbstractWriter
+from flow.record.context import get_app_context, match_record_with_context
+from flow.record.selector import Selector, make_selector
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from flow.record.base import Record
+
+
+DEFAULT_BATCH_SIZE = 1000
+DEFAULT_COMPRESSION = "zstd"
+
+__usage__ = f"""
+Apache Arrow adapter
+---
+Write usage: rdump -w arrow://[PATH]?batch_size=[BATCH_SIZE]&compression=[COMPRESSION]
+Read usage: rdump arrow://[PATH]
+[PATH]: path to file. Leave empty or "-" to output to stdout
+
+Optional parameters:
+    [BATCH_SIZE]: number of records to write in a single batch (default: {DEFAULT_BATCH_SIZE})
+    [COMPRESSION]: compression algorithm to use: "zstd", "lz4", or "none" (default: {DEFAULT_COMPRESSION})
+"""
+
+log = logging.getLogger(__name__)
+
+# Mapping of flow.record field types to pyarrow types.
+ARROW_TYPE_MAP = {
+    "boolean": pa.bool_(),
+    "datetime": pa.timestamp("us", tz="UTC"),
+    "filesize": pa.uint64(),
+    "uint8": pa.uint8(),
+    "uint16": pa.uint16(),
+    "uint32": pa.uint32(),
+    "float": pa.float64(),
+    "string": pa.string(),
+    "unix_file_mode": pa.uint16(),
+    "varint": pa.int64(),  # use int64 for varint, not ideal but Arrow has no varint type
+    "wstring": pa.string(),
+    "uri": pa.string(),
+    "digest": pa.struct(
+        {
+            "md5": pa.binary(length=16),
+            "sha1": pa.binary(length=20),
+            "sha256": pa.binary(length=32),
+        }
+    ),
+    "bytes": pa.binary(),
+}
+
+# Mapping of pyarrow type checks to flow.record field types.
+RECORD_TYPE_MAP = {
+    pa.types.is_floating: "float",
+    pa.types.is_integer: "varint",
+    pa.types.is_boolean: "boolean",
+    pa.types.is_binary: "bytes",
+    pa.types.is_timestamp: "datetime",
+    pa.types.is_string: "string",
+}
+
+
+def descriptor_to_arrow_schema(descriptor: RecordDescriptor) -> pa.Schema:
+    """Convert a flow.record RecordDescriptor to a pyarrow Schema."""
+    fields = []
+    for field_name, field_type in descriptor.get_all_fields().items():
+        log.debug("Mapping field '%s' of type '%s' to Arrow type", field_name, field_type)
+        type_name = field_type.typename
+        pa_type = ARROW_TYPE_MAP.get(type_name, pa.string())
+        fields.append(pa.field(field_name, pa_type))
+
+    metadata = {
+        b"descriptor_name": descriptor.name.encode("utf-8"),
+        b"descriptor_fields": ",".join(f"{fname}:{ftype}" for ftype, fname in descriptor.get_field_tuples()).encode(
+            "utf-8"
+        ),
+    }
+    log.debug("Arrow schema metadata: %s", metadata)
+    return pa.schema(fields, metadata=metadata)
+
+
+def as_pyarrowdict(record: Record) -> dict:
+    """Convert a Record to a dictionary with values compatible with pyarrow."""
+    desc = record._desc
+    d = record._asdict()
+    for field in desc.getfields("digest", all_fields=True):
+        value = d[field.name]
+        if value is not None:
+            d[field.name] = dict(value)
+    return d
+
+
+def arrow_schema_to_descriptor(schema: pa.Schema) -> RecordDescriptor:
+    """Convert a pyarrow Schema to a flow.record RecordDescriptor."""
+
+    # Check for embedded flow.record descriptor metadata
+    metadata = schema.metadata or {}
+    descriptor_name = metadata.get(b"descriptor_name", b"arrow/record").decode("utf-8")
+    if descriptor_fields := metadata.get(b"descriptor_fields", b"").decode("utf-8"):
+        fields = [
+            (ftype, name) for field_def in descriptor_fields.split(",") for name, ftype in [field_def.split(":", 1)]
+        ]
+        log.debug("Extracted embedded descriptor fields: %s", fields)
+        return RecordDescriptor(name=descriptor_name, fields=fields)
+
+    # No embedded descriptor, attempt to generate one from the schema
+    fields = []
+    for field in schema:
+        # Skip internal fields
+        if field.startswith("_"):
+            continue
+
+        pa_type = field.type
+        log.debug("Mapping Arrow field %r of type %r to flow.record type", field.name, pa_type)
+
+        # Find matching typename
+        typename = next(
+            (typename for check, typename in RECORD_TYPE_MAP.items() if check(pa_type)),
+            "string",
+        )
+        fields.append((typename, field.name))
+
+    return RecordDescriptor(name=descriptor_name, fields=fields)
+
+
+class ArrowWriter(AbstractWriter):
+    def __init__(
+        self,
+        path: str,
+        *,
+        batch_size: str | int = 1000,
+        compression: Literal["zstd", "lz4", "none"] | None = "zstd",
+        **kwargs,
+    ):
+        self.path = path
+        self.compression = compression
+        self.batch_size = int(batch_size)
+        self.descriptors_seen = set()
+        self.current_descriptor: RecordDescriptor | None = None
+        self.batch: list[Record] = []
+        self.schema = None
+
+        if self.compression and self.compression.lower() == "none":
+            self.compression = None
+
+        self.fp = open_path_or_stream(path, "wb")
+        self.stream_writer = None
+
+        self.ipc_options = pa.ipc.IpcWriteOptions(compression=self.compression)
+
+    def write(self, record: Record) -> None:
+        """Write a record to the database"""
+
+        # if this is a new descriptor, flush existing batch and create new schema
+        descriptor = record._desc
+        if descriptor != self.current_descriptor:
+            self.flush()
+            self.current_descriptor = descriptor
+            self.schema = descriptor_to_arrow_schema(descriptor)
+            self.stream_writer = pa.ipc.new_stream(self.fp, self.schema, options=self.ipc_options)
+
+        self.batch.append(record)
+
+        # Commit every batch_size records
+        if len(self.batch) % self.batch_size == 0:
+            self.flush()
+
+    def close(self) -> None:
+        self.flush()
+        if self.fp:
+            self.fp.close()
+
+    def flush(self) -> None:
+        log.debug("Flushing %d records to Arrow stream (%r)", len(self.batch), self.stream_writer)
+        if self.batch:
+            batch = pa.Table.from_pylist(
+                [as_pyarrowdict(r) for r in self.batch],
+                schema=self.schema,
+            )
+            self.stream_writer.write_table(batch)
+            self.batch = []
+
+
+def iter_record_batch(stream: pa.RecordBatchReader, fp: BinaryIO) -> Iterator[pa.RecordBatch]:
+    """Iterate over RecordBatches from a RecordBatchReader.
+
+    Argument:
+        stream: Arrow RecordBatchReader
+
+    Yields:
+        Arrow RecordBatch
+    """
+    while True:
+        try:
+            # check for end of batch stream
+            msg_type = fp.peek(10)[8:9]
+            log.info("Message type: %s", msg_type)
+            if msg_type != b"\x14":
+                break
+            batch = stream.read_next_batch()
+            log.debug("Read RecordBatch with %d rows", batch.num_rows)
+            yield batch
+        except StopIteration:
+            break
+
+
+def iter_ipc_streams(fp: BinaryIO) -> Iterator[pa.RecordBatchReader]:
+    """Iterate over Arrow IPC streams from a file-like object.
+
+    This handles multiple streams in a single file. And thus multiple schemas.
+    Note: pyarrow does not have a built-in way to handle multiple streams in a single file,
+    so we attempt to open streams until we reach the end of the file.
+
+    Argument:
+        fp: file-like object to read from
+
+    Yields:
+        Arrow RecordBatchReader for each stream
+    """
+
+    # keep trying to open streams until we reach end of file or get an invalid stream
+    with contextlib.suppress(pa.ArrowInvalid):
+        while True:
+            log.debug("Opening stream at position: %s", fp.tell())
+            stream = pa.ipc.open_stream(fp)
+            yield stream
+
+
+class ArrowReader(AbstractReader):
+    """Apache Arrow reader.
+
+    This supports reading multiple Arrow IPC streams from a single file.
+    However, this is not commonly supported by other tools.
+
+    It supports flow.record embedded RecordDescriptor metadata for accurate type mapping.
+    Otherwise, it will attempt to infer types from Arrow schema.
+    """
+
+    def __init__(self, path: str, selector: Selector | str | None = None, **kwargs):
+        self.path = path
+        self.selector = make_selector(selector)
+        self.fp = open_path_or_stream(path, "rb")
+
+    def close(self) -> None:
+        log.info("Closing ArrowReader for path: %s", self.path)
+        if self.fp:
+            self.fp.close()
+
+    def __iter__(self) -> Iterator[Record]:
+        ctx = get_app_context()
+        selector = self.selector
+
+        for stream in iter_ipc_streams(self.fp):
+            log.debug("Reading new Arrow IPC stream with schema: %s", stream.schema)
+            for batch in iter_record_batch(stream, self.fp):
+                # Convert descriptor once per batch, not per row
+                descriptor = arrow_schema_to_descriptor(batch.schema)
+
+                # Use to_pydict() for columnar access, more efficient for large batches
+                batch_dict = batch.to_pydict()
+                num_rows = len(next(iter(batch_dict.values())))
+
+                for i in range(num_rows):
+                    row_dict = {k: v[i] for k, v in batch_dict.items()}
+                    record = descriptor.init_from_dict(row_dict)
+                    if match_record_with_context(record, selector, ctx):
+                        yield record

--- a/flow/record/adapter/parquet.py
+++ b/flow/record/adapter/parquet.py
@@ -88,6 +88,7 @@ def get_fieldnames_for_fieldtype(descriptor: RecordDescriptor, fieldtype: str) -
     Argument:
         descriptor: RecordDescriptor to search
         fieldtype: field type to match
+
     Returns:
         List of field names matching the field type
     """

--- a/flow/record/adapter/parquet.py
+++ b/flow/record/adapter/parquet.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from functools import lru_cache
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from flow.record import Record, RecordDescriptor, fieldtypes, open_path_or_stream
+from flow.record.adapter import AbstractReader, AbstractWriter
+from flow.record.base import is_valid_field_name
+from flow.record.context import get_app_context, match_record_with_context
+from flow.record.selector import Selector, make_selector
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from flow.record.base import Record
+
+DEFAULT_BATCH_SIZE = 1000
+DEFAULT_COMPRESSION = "zstd"
+
+__usage__ = f"""
+Apache Parquet adapter
+---
+Write usage: rdump -w parquet://[PATH]?batch_size=[BATCH_SIZE]&compression=[COMPRESSION]
+Read usage: rdump parquet://[PATH]
+[PATH]: path to file. Leave empty or "-" to output to stdout
+
+Optional parameters:
+    [BATCH_SIZE]: number of records to write in a single batch (default: {DEFAULT_BATCH_SIZE})
+    [COMPRESSION]: compression algorithm to use: "snappy", "gzip", "brotli", "zstd", "lz4", or "none" (default: {DEFAULT_COMPRESSION})
+"""  # noqa: E501
+
+log = logging.getLogger(__name__)
+
+
+# Mapping of flow.record field type names to pyarrow types.
+RECORD_TO_ARROW_TYPE_MAP = {
+    "boolean": pa.bool_(),
+    "datetime": pa.timestamp("us", tz="UTC"),
+    "filesize": pa.uint64(),
+    "uint16": pa.uint16(),
+    "uint32": pa.uint32(),
+    "float": pa.float64(),
+    "string": pa.string(),
+    "unix_file_mode": pa.uint16(),
+    "varint": pa.int64(),  # use int64 for varint, not ideal but Arrow has no varint type
+    "wstring": pa.string(),
+    "uri": pa.string(),
+    "digest": pa.struct(
+        {
+            "md5": pa.binary(length=16),
+            "sha1": pa.binary(length=20),
+            "sha256": pa.binary(length=32),
+        }
+    ),
+    "bytes": pa.binary(),
+    "path": pa.struct(
+        {
+            "path": pa.string(),
+            "path_type": pa.uint8(),
+        }
+    ),
+}
+
+# Mapping of pyarrow type checks to flow.record field type names
+# This is only used when there is no known RecordDescriptor schema available
+ARROW_TO_RECORD_TYPE_MAP = {
+    pa.types.is_floating: "float",
+    pa.types.is_uint16: "uint16",
+    pa.types.is_uint32: "uint32",
+    pa.types.is_integer: "varint",
+    pa.types.is_boolean: "boolean",
+    pa.types.is_binary: "bytes",
+    pa.types.is_timestamp: "datetime",
+    pa.types.is_string: "string",
+}
+
+
+@lru_cache(maxsize=128)
+def get_fieldnames_for_fieldtype(descriptor: RecordDescriptor, fieldtype: str) -> list[str]:
+    """Get a list of field names in the descriptor that match the given field type.
+
+    Argument:
+        descriptor: RecordDescriptor to search
+        fieldtype: field type to match
+    Returns:
+        List of field names matching the field type
+    """
+    return [fname for ftype, fname in descriptor.get_field_tuples() if ftype == fieldtype]  # type: ignore
+
+
+@lru_cache(maxsize=128)
+def descriptor_to_arrow_schema(descriptor: RecordDescriptor) -> pa.Schema:
+    """Convert a flow.record RecordDescriptor to a pyarrow Schema."""
+    fields = []
+    for field_name, field_type in descriptor.get_all_fields().items():
+        log.debug("Mapping field %r of type %r to Arrow type", field_name, field_type)
+        type_name = field_type.typename
+        pa_type = RECORD_TO_ARROW_TYPE_MAP.get(type_name, pa.string())
+        fields.append(pa.field(field_name, pa_type))
+
+    metadata = {
+        b"descriptor_name": descriptor.name.encode("utf-8"),
+        b"descriptor_fields": ",".join(f"{fname}:{ftype}" for ftype, fname in descriptor.get_field_tuples()).encode(
+            "utf-8"
+        ),
+    }
+    log.debug("Arrow schema metadata: %s", metadata)
+    return pa.schema(fields, metadata=metadata)
+
+
+@lru_cache(maxsize=128)
+def record_to_pyarrowdict(record: Record) -> dict:
+    """Convert a Record to a dictionary with values compatible with pyarrow.
+
+    Arguments:
+        record: Record to convert
+
+    Returns:
+        Dictionary with pyarrow-compatible values
+    """
+    desc = record._desc
+    d = record._asdict()
+
+    # serialize path type
+    for field in get_fieldnames_for_fieldtype(desc, "path"):
+        if (value := d[field]) is not None:
+            path, path_type = value._pack()
+            d[field] = {"path": path, "path_type": path_type}
+
+    # serialize digest type
+    for field in get_fieldnames_for_fieldtype(desc, "digest"):
+        if (value := d[field]) is not None:
+            md5, sha1, sha256 = value._pack()
+            d[field] = {"md5": md5, "sha1": sha1, "sha256": sha256}
+
+    return d
+
+
+def pyarrowdict_to_record(
+    row_dict: dict,
+    descriptor: RecordDescriptor,
+    rename_fields: dict[str, str] | None = None,
+) -> Record:
+    """Convert a pyarrow row dictionary to a Record, handling special field types.
+
+    Arguments:
+        row_dict: dictionary of field values from pyarrow
+        descriptor: RecordDescriptor to use for creating the Record
+        rename_fields: optional mapping of original field names to renamed field names
+
+    Returns:
+        Record created from the pyarrow row dictionary
+    """
+    # deserialize path type
+    for field in get_fieldnames_for_fieldtype(descriptor, "path"):
+        if (value := row_dict.get(field)) is not None:
+            row_dict[field] = fieldtypes.path._unpack(data=(value["path"], value["path_type"]))
+
+    # deserialize digest type
+    for field in get_fieldnames_for_fieldtype(descriptor, "digest"):
+        if (value := row_dict.get(field)) is not None:
+            row_dict[field] = fieldtypes.digest._unpack(data=(value["md5"], value["sha1"], value["sha256"]))
+
+    # it's possible that some field names were renamed to be valid flow.record field names, remap them here
+    if rename_fields:
+        for old_key, new_key in rename_fields.items():
+            if old_key in row_dict:
+                row_dict[new_key] = row_dict.pop(old_key)
+
+    return descriptor.init_from_dict(row_dict)
+
+
+@lru_cache(maxsize=128)
+def arrow_schema_to_descriptor(
+    schema: pa.Schema,
+) -> tuple[RecordDescriptor, dict[str, str]]:
+    """Convert a pyarrow Schema to a flow.record RecordDescriptor.
+
+    This function also returns a mapping of original field names to renamed field names
+    in case any field names were modified to be valid flow.record field names. For example,
+    spaces and special characters are replaced with underscores. This mapping can be used
+    when reading records to ensure the field names match those in the descriptor.
+
+    Argument:
+        schema: pyarrow Schema to convert
+
+    Returns:
+        RecordDescriptor and mapping of original field names to renamed field names
+    """
+
+    # Check for embedded flow.record descriptor metadata
+    metadata = schema.metadata or {}
+    descriptor_name = metadata.get(b"descriptor_name", b"parquet/record").decode("utf-8")
+    if descriptor_fields := metadata.get(b"descriptor_fields", b"").decode("utf-8"):
+        fields = [
+            (ftype, name) for field_def in descriptor_fields.split(",") for name, ftype in [field_def.split(":", 1)]
+        ]
+        log.debug("Extracted embedded descriptor fields: %s", fields)
+        return RecordDescriptor(name=descriptor_name, fields=fields), {}
+
+    # No embedded descriptor, attempt to generate one from the schema
+    fields = []
+    field_name_mappings = {}
+    for field in schema:
+        field_type = field.type
+        field_name = field.name
+
+        # replace common invalid characters in field names
+        original_field_name = field_name
+        field_name = original_field_name.replace(" ", "_").replace("-", "_").replace(".", "_")
+
+        # Skip reserved or invalid field names
+        if not is_valid_field_name(field_name):
+            log.warning(
+                "Dropping invalid field name in Arrow schema: %r (original: %r)",
+                field_name,
+                original_field_name,
+            )
+            continue
+
+        if field_name != original_field_name:
+            log.debug("Renaming field %r to %r for flow.record compatibility", original_field_name, field_name)
+            field_name_mappings[original_field_name] = field_name
+
+        log.debug(
+            "Mapping Arrow field %r of type %r to flow.record type",
+            field_name,
+            field_type,
+        )
+
+        # Find matching typename
+        typename = next(
+            (typename for check, typename in ARROW_TO_RECORD_TYPE_MAP.items() if check(field_type)),
+            "string",
+        )
+        fields.append((typename, field_name))
+
+    return RecordDescriptor(name=descriptor_name, fields=fields), field_name_mappings
+
+
+class ParquetWriter(AbstractWriter):
+    def __init__(
+        self,
+        path: str,
+        *,
+        batch_size: str | int = DEFAULT_BATCH_SIZE,
+        compression: (Literal["snappy", "gzip", "brotli", "zstd", "lz4", "none"] | None) = "zstd",
+        **kwargs,
+    ):
+        self.path = Path(path)
+        self.compression = compression
+        self.batch_size = int(batch_size)
+        self.descriptors_seen = set()
+        self.batch: list[Record] = []
+        self.schema = None
+
+        if compression.lower() == "none":
+            self.compression = None
+
+        # self.fp = open_path_or_stream(path, "wb")
+        self.stream_writer = None
+        self.parquet_writers = {}
+        self.writer_batch: defaultdict[tuple[str, int], list[Record]] = defaultdict(list)
+
+    def write(self, record: Record) -> None:
+        """Write a record to the current batch. Flushes the batch to disk if ``batch_size`` is reached.
+
+        Note: This implementation creates separate Parquet files for each RecordDescriptor.
+        This is because Parquet files only support a single schema per file. The first descriptor uses the given path,
+        and subsequent descriptors create new files with unique names based on the descriptor.
+
+        Argument:
+            record: Record to write
+        """
+        descriptor = record._desc
+
+        # if this is a new descriptor, create a new ParquetWriter
+        if descriptor.identifier not in self.parquet_writers:
+            schema = descriptor_to_arrow_schema(descriptor)
+
+            # First time seeing this descriptor, create a new ParquetWriter
+            output_path = self.path
+
+            # Create unique output path if multiple descriptors are seen
+            if len(self.parquet_writers) > 0:
+                desc_id = f"{descriptor.name.replace('/', '_')}_{descriptor.descriptor_hash:x}"
+                output_path = self.path.with_stem(self.path.stem + f"_{desc_id}")
+
+            # Create and register ParquetWriter
+            writer = pq.ParquetWriter(
+                output_path,
+                schema=schema,
+                compression=self.compression,
+            )
+            self.parquet_writers[descriptor.identifier] = writer
+
+        # Add record to the descriptor-specific batch
+        self.writer_batch[descriptor.identifier].append(record)
+
+        # Commit every batch_size records
+        if len(self.writer_batch[descriptor.identifier]) % self.batch_size == 0:
+            self.flush_writer(descriptor.identifier)
+
+    def close(self) -> None:
+        """Flush and close any open Parquet writers."""
+        for identifier, writer in self.parquet_writers.items():
+            self.flush_writer(identifier)
+            writer.close()
+
+        self.parquet_writers.clear()
+        self.writer_batch.clear()
+
+    def flush_writer(self, indentifier: tuple[str, int]) -> None:
+        """Flush the record batch of the Parquet writer identified by ``identifier`` to disk."""
+        batch_records = self.writer_batch[indentifier]
+        if not batch_records:
+            return
+
+        descriptor = batch_records[0]._desc
+        table = pa.Table.from_pylist(
+            [record_to_pyarrowdict(r) for r in batch_records],
+            schema=descriptor_to_arrow_schema(descriptor),
+        )
+        writer = self.parquet_writers[indentifier]
+        writer.write_table(table)
+        self.writer_batch[indentifier] = []
+
+    def flush(self) -> None:
+        """Flush the current record batch to disk for all descriptors."""
+        for identifier in list(self.writer_batch.keys()):
+            self.flush_writer(identifier)
+
+
+class ParquetReader(AbstractReader):
+    """Apache Parquet reader."""
+
+    def __init__(
+        self,
+        path: str,
+        selector: Selector | str | None = None,
+        fields: list[str] | str | None = None,
+        exclude: list[str] | str | None = None,
+        **kwargs,
+    ):
+        self.path = path
+        self.selector = make_selector(selector)
+
+        self.fields = fields
+        self.exclude = exclude
+        if isinstance(self.fields, str):
+            self.fields = self.fields.split(",")
+        if isinstance(self.exclude, str):
+            self.exclude = self.exclude.split(",")
+
+        source = open_path_or_stream(path, "rb") if path in (None, "", "-") else path
+        self.parquet_file = pq.ParquetFile(source)
+        self.num_rows = self.parquet_file.metadata.num_rows
+        log.info(
+            "Opened Parquet file with %u of rows (%u row groups).",
+            self.num_rows,
+            self.parquet_file.num_row_groups,
+        )
+
+    def close(self) -> None:
+        log.info("Closing ParquetReader for path: %s", self.path)
+        if self.parquet_file:
+            self.parquet_file.close()
+            self.parquet_file = None
+
+    def __iter__(self) -> Iterator[Record]:
+        ctx = get_app_context()
+        selector = self.selector
+        descriptor, field_name_mappings = arrow_schema_to_descriptor(self.parquet_file.schema_arrow)
+
+        # determine which descriptor columns to read based on fields/exclude
+        columns = None
+        if self.fields or self.exclude:
+            columns = set(descriptor.get_all_fields())
+            if self.fields:
+                columns = columns & set(self.fields)
+            if self.exclude:
+                columns = columns - set(self.exclude)
+            log.debug("Reading Parquet columns: %r", columns)
+
+        for row_group_idx in range(self.parquet_file.num_row_groups):
+            table = self.parquet_file.read_row_group(row_group_idx, columns=columns)
+            batch_dict = table.to_pydict()
+            num_rows = len(next(iter(batch_dict.values())))
+
+            for i in range(num_rows):
+                row_dict = {k: v[i] for k, v in batch_dict.items()}
+                record = pyarrowdict_to_record(
+                    row_dict,
+                    descriptor=descriptor,
+                    rename_fields=field_name_mappings,
+                )
+                if match_record_with_context(record, selector, ctx):
+                    yield record

--- a/flow/record/fieldtypes/__init__.py
+++ b/flow/record/fieldtypes/__init__.py
@@ -439,6 +439,11 @@ class digest(FieldType):
     def __repr__(self) -> str:
         return f"(md5={self.md5}, sha1={self.sha1}, sha256={self.sha256})"
 
+    def __iter__(self) -> Iterator[tuple[str, str | None]]:
+        yield "md5", self.md5
+        yield "sha1", self.sha1
+        yield "sha256", self.sha256
+
     @property
     def md5(self) -> str | None:
         return self.__md5
@@ -452,41 +457,68 @@ class digest(FieldType):
         return self.__sha256
 
     @md5.setter
-    def md5(self, val: str | None) -> None:
+    def md5(self, val: str | _bytes | None) -> None:
         if val is None:
             self.__md5 = self.__md5_bin = None
             return
+
+        if isinstance(val, _bytes):
+            if len(val) != 16:
+                raise TypeError(f"Incorrect binary MD5 hash length: {len(val)}, expected 16")
+            self.__md5_bin = val
+            self.__md5 = val.hex()
+            return
+
+        # Assume string
         try:
-            self.__md5_bin = a2b_hex(val)
-            self.__md5 = val
-            if len(self.__md5_bin) != 16:
+            if len(val) != 32:
                 raise TypeError("Incorrect hash length")  # noqa: TRY301
+            self.__md5_bin = a2b_hex(val)
+            self.__md5 = val.lower()
         except (binascii.Error, TypeError) as e:
             raise TypeError(f"Invalid MD5 value {val!r}, {e}")
 
     @sha1.setter
-    def sha1(self, val: str | None) -> None:
+    def sha1(self, val: str | _bytes | None) -> None:
         if val is None:
             self.__sha1 = self.__sha1_bin = None
             return
+
+        if isinstance(val, _bytes):
+            if len(val) != 20:
+                raise TypeError(f"Incorrect binary SHA-1 hash length: {len(val)}, expected 20")
+            self.__sha1_bin = val
+            self.__sha1 = val.hex()
+            return
+
+        # Assume string
         try:
-            self.__sha1_bin = a2b_hex(val)
-            self.__sha1 = val
-            if len(self.__sha1_bin) != 20:
+            if len(val) != 40:
                 raise TypeError("Incorrect hash length")  # noqa: TRY301
+            self.__sha1_bin = a2b_hex(val)
+            self.__sha1 = val.lower()
         except (binascii.Error, TypeError) as e:
             raise TypeError(f"Invalid SHA-1 value {val!r}, {e}")
 
     @sha256.setter
-    def sha256(self, val: str | None) -> None:
+    def sha256(self, val: str | _bytes | None) -> None:
         if val is None:
             self.__sha256 = self.__sha256_bin = None
             return
+
+        if isinstance(val, _bytes):
+            if len(val) != 32:
+                raise TypeError(f"Incorrect binary SHA-256 hash length: {len(val)}, expected 32")
+            self.__sha256_bin = val
+            self.__sha256 = val.hex()
+            return
+
+        # Assume string
         try:
-            self.__sha256_bin = a2b_hex(val)
-            self.__sha256 = val
-            if len(self.__sha256_bin) != 32:
+            if len(val) != 64:
                 raise TypeError("Incorrect hash length")  # noqa: TRY301
+            self.__sha256_bin = a2b_hex(val)
+            self.__sha256 = val.lower()
         except (binascii.Error, TypeError) as e:
             raise TypeError(f"Invalid SHA-256 value {val!r}, {e}")
 
@@ -505,6 +537,11 @@ class digest(FieldType):
             b2a_hex(data[2]).decode() if data[2] else None,
         )
         return cls(value)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, digest):
+            return self._pack() == other._pack()
+        return super().__eq__(other)
 
 
 class uri(string, FieldType):

--- a/flow/record/fieldtypes/__init__.py
+++ b/flow/record/fieldtypes/__init__.py
@@ -12,8 +12,11 @@ from binascii import a2b_hex, b2a_hex
 from datetime import datetime as _dt
 from datetime import timezone
 from posixpath import basename, dirname
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 try:
     try:
@@ -60,7 +63,8 @@ def flow_record_tz(*, default_tz: str = "UTC") -> ZoneInfo | UTC | None:
     if not HAS_ZONE_INFO:
         if tz != "UTC":
             warnings.warn(
-                "Cannot use FLOW_RECORD_TZ due to missing zoneinfo module, defaulting to 'UTC'.", stacklevel=2
+                "Cannot use FLOW_RECORD_TZ due to missing zoneinfo module, defaulting to 'UTC'.",
+                stacklevel=2,
             )
         return UTC
 

--- a/flow/record/stream.py
+++ b/flow/record/stream.py
@@ -147,7 +147,12 @@ class RecordStreamReader(AbstractReader):
             pass
 
 
-def record_stream(sources: list[str], selector: str | None = None) -> Iterator[Record]:
+def record_stream(
+    sources: list[str],
+    selector: str | None = None,
+    fields: list[str] | None = None,
+    exclude: list[str] | None = None,
+) -> Iterator[Record]:
     """Return a Record stream generator from the given Record sources.
 
     If there are multiple sources, exceptions are caught and logged, and the stream continues with the next source.
@@ -166,7 +171,7 @@ def record_stream(sources: list[str], selector: str | None = None) -> Iterator[R
         # Initial value for reader, in case of exception message
         reader: str | AbstractReader = "RecordReader"
         try:
-            reader = RecordReader(src, selector=selector)
+            reader = RecordReader(src, selector=selector, fields=fields, exclude=exclude)
             yield from reader
         except EOFError as e:
             # End of file reached, likely no records in source
@@ -184,7 +189,12 @@ def record_stream(sources: list[str], selector: str | None = None) -> Iterator[R
             if len(sources) == 1:
                 raise
             else:
-                log.warning("Exception in %r for %r: %s -- skipping to next reader", reader, src, aRepr.repr(e))
+                log.warning(
+                    "Exception in %r for %r: %s -- skipping to next reader",
+                    reader,
+                    src,
+                    aRepr.repr(e),
+                )
                 continue
         finally:
             if isinstance(reader, AbstractReader):
@@ -270,7 +280,12 @@ class PathTemplateWriter:
 class RecordArchiver(PathTemplateWriter):
     """RecordWriter that writes/archives records to a path with YYYY/mm/dd."""
 
-    def __init__(self, archive_path: str, path_template: str | None = None, name: str | None = None):
+    def __init__(
+        self,
+        archive_path: str,
+        path_template: str | None = None,
+        name: str | None = None,
+    ):
         path_template = path_template or self.DEFAULT_TEMPLATE
         template = str(Path(archive_path) / "{ts:%Y/%m/%d}" / path_template)
         PathTemplateWriter.__init__(self, path_template=template, name=name)
@@ -280,7 +295,10 @@ class RecordFieldRewriter:
     """Rewrite records using a new RecordDescriptor for chosen fields and/or excluded or new record fields."""
 
     def __init__(
-        self, fields: list[str] | None = None, exclude: list[str] | None = None, expression: str | None = None
+        self,
+        fields: list[str] | None = None,
+        exclude: list[str] | None = None,
+        expression: str | None = None,
     ):
         self.fields = fields or []
         self.exclude = exclude or []

--- a/flow/record/tools/rdump.py
+++ b/flow/record/tools/rdump.py
@@ -169,6 +169,18 @@ def main(argv: list[str] | None = None) -> int:
         help="Fields (comma seperated) to exclude in dumping",
     )
     selection.add_argument(
+        "-Fr",
+        "--fields-read",
+        metavar="FIELDS",
+        help="Fields (comma seperated) to include in reading",
+    )
+    selection.add_argument(
+        "-Xr",
+        "--exclude-read",
+        metavar="FIELDS",
+        help="Fields (comma seperated) to exclude in reading",
+    )
+    selection.add_argument(
         "-s",
         "--selector",
         metavar="SELECTOR",
@@ -365,7 +377,11 @@ def main(argv: list[str] | None = None) -> int:
     selector = make_selector(args.selector, not args.no_compile)
     seen_desc = set()
     islice_stop = (args.count + args.skip) if args.count else None
-    record_iterator = islice(record_stream(args.src, selector), args.skip, islice_stop)
+    record_iterator = islice(
+        record_stream(args.src, selector, fields=args.fields_read, exclude=args.exclude_read),
+        args.skip,
+        islice_stop,
+    )
 
     ctx = get_app_context()
     ctx.source_total = len(args.src)

--- a/flow/record/tools/rdump.py
+++ b/flow/record/tools/rdump.py
@@ -160,25 +160,25 @@ def main(argv: list[str] | None = None) -> int:
         "-F",
         "--fields",
         metavar="FIELDS",
-        help="Fields (comma seperated) to output in dumping",
+        help="Fields (comma separated) to output in dumping",
     )
     selection.add_argument(
         "-X",
         "--exclude",
         metavar="FIELDS",
-        help="Fields (comma seperated) to exclude in dumping",
+        help="Fields (comma separated) to exclude in dumping",
     )
     selection.add_argument(
         "-Fr",
         "--fields-read",
         metavar="FIELDS",
-        help="Fields (comma seperated) to include in reading",
+        help="Fields (comma separated) to include during reading, if supported by the adapter",
     )
     selection.add_argument(
         "-Xr",
         "--exclude-read",
         metavar="FIELDS",
-        help="Fields (comma seperated) to exclude in reading",
+        help="Fields (comma separated) to exclude during reading, if supported by the adapter",
     )
     selection.add_argument(
         "-s",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,12 @@ geoip = [
 avro = [
     "fastavro[snappy]",
 ]
+arrow = [
+    "pyarrow",
+]
+parquet = [
+    "pyarrow",
+]
 duckdb = [
     "duckdb; platform_python_implementation != 'PyPy'", # Don't install duckdb on PyPy
     "pytz; platform_python_implementation != 'PyPy'", # Don't install duckdb on PyPy
@@ -89,12 +95,19 @@ splunk = [
 xlsx = [
     "openpyxl",
 ]
+arrow = [
+    "pyarrow",
+]
+parquet = [
+    "pyarrow",
+]
 test = [
     {include-group = "compression"},
     {include-group = "avro"},
     {include-group = "elastic"},
     {include-group = "xlsx"},
     {include-group = "duckdb"},
+    {include-group = "parquet"},
     "tqdm",
     "structlog",
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ test = [
     {include-group = "elastic"},
     {include-group = "xlsx"},
     {include-group = "duckdb"},
-    {include-group = "parquet"},
+    "pyarrow; platform_python_implementation != 'PyPy'", # Don't install pyarrow on PyPy
     "tqdm",
     "structlog",
     "pytest",

--- a/tests/_data/iris_zstd.parquet
+++ b/tests/_data/iris_zstd.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa0e188bd9fa4c2fb6a09f7a04f11c96421ef9f8cfdac0c7cfabab91971bda83
+size 1997

--- a/tests/_docs/conf.py
+++ b/tests/_docs/conf.py
@@ -36,4 +36,5 @@ autosectionlabel_prefix_document = True
 suppress_warnings = [
     # https://github.com/readthedocs/sphinx-autoapi/issues/285
     "autoapi.python_import_resolution",
+    "ref.python",
 ]

--- a/tests/adapter/test_arrow.py
+++ b/tests/adapter/test_arrow.py
@@ -2,6 +2,8 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("pyarrow")
+
 from flow.record import RecordDescriptor
 from flow.record.adapter.arrow import ArrowReader, ArrowWriter
 from tests._utils import generate_plain_records

--- a/tests/adapter/test_arrow.py
+++ b/tests/adapter/test_arrow.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+import pytest
+
+from flow.record import RecordDescriptor
+from flow.record.adapter.arrow import ArrowReader, ArrowWriter
+from tests._utils import generate_plain_records
+
+
+@pytest.mark.parametrize("compression", ["none", "lz4", "zstd"])
+def test_arrow_adapter_roundtrip(tmp_path: Path, compression: str) -> None:
+    """Test writing and reading records using Arrow adapter."""
+
+    records = list(generate_plain_records(count=100))
+    output_path = tmp_path / f"test_roundtrip_{compression}.arrow"
+
+    with ArrowWriter(output_path, compression=compression) as writer:
+        for record in records:
+            writer.write(record)
+
+    with ArrowReader(output_path) as reader:
+        read_records = list(reader)
+
+    assert len(read_records) == len(records)
+    for original, read in zip(records, read_records, strict=False):
+        assert original._asdict() == read._asdict()
+        assert original == read
+        assert original._desc == read._desc
+
+
+def test_arrow_stream_with_multiple_descriptors(tmp_path: Path) -> None:
+    """Test writing and reading records with multiple descriptors using Arrow adapter."""
+
+    MovieRecord = RecordDescriptor("movie/record", [("string", "title"), ("uint16", "year")])
+    ActorRecord = RecordDescriptor("actor/record", [("string", "name"), ("uint16", "birth_year")])
+
+    records = []
+    records.append(MovieRecord("Inception", 2010))
+    records.append(ActorRecord("Leonardo DiCaprio", 1974))
+    records.append(MovieRecord("The Matrix", 1999))
+    records.append(ActorRecord("Keanu Reeves", 1964))
+    records.append(MovieRecord("Interstellar", 2014))
+    records.append(ActorRecord("Matthew McConaughey", 1969))
+
+    with ArrowWriter(tmp_path / "movies_and_actors.arrow") as writer:
+        for record in records:
+            writer.write(record)
+
+    with ArrowReader(tmp_path / "movies_and_actors.arrow") as reader:
+        read_records = list(reader)
+
+    assert len(read_records) == len(records)
+    for original, read in zip(records, read_records, strict=False):
+        assert original._asdict() == read._asdict()
+        assert original == read
+        assert original._desc == read._desc

--- a/tests/adapter/test_parquet.py
+++ b/tests/adapter/test_parquet.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("pyarrow")
+
 from flow.record import RecordDescriptor, RecordReader, RecordWriter
 from flow.record.adapter.parquet import ParquetReader, ParquetWriter
 from flow.record.tools import rdump

--- a/tests/adapter/test_parquet.py
+++ b/tests/adapter/test_parquet.py
@@ -1,0 +1,195 @@
+from hashlib import md5, sha1, sha256
+from pathlib import Path
+
+import pytest
+
+from flow.record import RecordDescriptor, RecordReader, RecordWriter
+from flow.record.adapter.parquet import ParquetReader, ParquetWriter
+from tests._utils import generate_plain_records
+
+
+def test_parquet_adapter_roundtrip(tmp_path: Path) -> None:
+    """Test writing and reading records using Parquet adapter."""
+    TestRecord = RecordDescriptor(
+        name="TestRecord",
+        fields=[
+            ("string", "name"),
+            ("uint16", "age"),
+            ("filesize", "file_size"),
+            ("varint", "count"),
+            ("digest", "hash"),
+            ("path", "file_path"),
+        ],
+    )
+
+    digest_value = (md5(b"test").hexdigest(), sha1(b"test").hexdigest(), sha256(b"test").hexdigest())
+
+    records = [
+        TestRecord("Alice", 30, 123456789, 1000, digest_value, "/home/alice"),
+        TestRecord("Bob", 25, 987654321, 2000, digest_value, "/home/bob"),
+    ]
+
+    # write records to Parquet file
+    with ParquetWriter(tmp_path / "test.parquet") as writer:
+        for record in records:
+            writer.write(record)
+
+    # read records back from Parquet file
+    with ParquetReader(tmp_path / "test.parquet") as reader:
+        read_records = list(reader)
+
+    # verify that the read records match the original records
+    assert len(read_records) == len(records)
+    for original, read in zip(records, read_records, strict=False):
+        assert original._asdict() == read._asdict()
+        assert original == read
+        assert original._desc == read._desc
+
+
+@pytest.mark.parametrize("compression", ["none", "snappy", "gzip", "brotli", "lz4", "zstd"])
+def test_parquet_compression(tmp_path: Path, compression: str) -> None:
+    """Test Parquet writing and reading with different compression algorithms."""
+    parq_path = tmp_path / "compressed.parquet"
+
+    # write with specified compression
+    with RecordWriter(f"parquet://{parq_path}?compression={compression}") as writer:
+        for record in generate_plain_records(count=100):
+            writer.write(record)
+
+    # read back and verify
+    with RecordReader(f"parquet://{parq_path}") as reader:
+        records = list(reader)
+    assert len(records) == 100
+
+
+@pytest.mark.parametrize("compression", ["none", "snappy", "gzip", "brotli", "lz4", "zstd"])
+@pytest.mark.parametrize("extension", [".parquet", ".parq", ".pq"])
+def test_parquet_extension_writing(tmp_path: Path, extension: str, compression: str) -> None:
+    """Test that RecordWriter can infer Parquet format from file extension."""
+    parq_path = tmp_path / f"data{extension}"
+
+    # write using a RecordWriter using a path with a parquet like extension
+    with RecordWriter(parq_path) as writer:
+        assert isinstance(writer, ParquetWriter)
+        for record in generate_plain_records(count=50):
+            writer.write(record)
+
+    # test if we get a ParquetReader based on the extension
+    with ParquetReader(parq_path) as reader:
+        assert isinstance(reader, ParquetReader)
+        records = list(reader)
+    assert len(records) == 50
+
+
+@pytest.mark.parametrize("extension", [".parquet", ".parq", ".pq"])
+def test_parquet_extension_reading(tmp_path: Path, extension: str) -> None:
+    """Test that RecordReader infers ParquetReader from file extension."""
+    parq_path = tmp_path / f"data{extension}"
+
+    # write using a ParquetWriter
+    with ParquetWriter(parq_path) as writer:
+        for record in generate_plain_records(count=50):
+            writer.write(record)
+
+    # test if we get a ParquetReader based on the extension
+    with RecordReader(parq_path) as reader:
+        assert isinstance(reader, ParquetReader)
+        records = list(reader)
+    assert len(records) == 50
+
+
+def test_parquet_invalid_compression(tmp_path: Path) -> None:
+    """Test that an invalid compression algorithm raises a ValueError."""
+    parq_path = tmp_path / "invalid_compression.parquet"
+
+    with RecordWriter(f"parquet://{parq_path}?compression=invalid_algo") as writer:
+        for record in generate_plain_records(count=10):
+            with pytest.raises(Exception, match="Unsupported compression: invalid_algo"):
+                writer.write(record)
+
+
+def test_parquet_missing_file(tmp_path: Path) -> None:
+    """Test that attempting to read a non-existent Parquet file raises FileNotFoundError."""
+    parq_path = tmp_path / "non_existent.parquet"
+
+    with pytest.raises(FileNotFoundError), ParquetReader(parq_path) as reader:
+        list(reader)
+
+
+def test_parquet_empty_file(tmp_path: Path) -> None:
+    """Test that reading an empty Parquet file raises an appropriate error."""
+    parq_path = tmp_path / "0_byte_file.parquet"
+    parq_path.touch()  # create an empty file
+
+    with pytest.raises(Exception, match="Parquet file size is 0 bytes"), ParquetReader(parq_path) as reader:
+        list(reader)
+
+
+def test_parquet_zero_records(tmp_path: Path) -> None:
+    """Test writing a Parquet file with zero records."""
+    parq_path = tmp_path / "zero_records.parquet"
+
+    with ParquetWriter(parq_path) as _writer:
+        pass  # do not write any records
+
+    # the above actually does not create a Parquet file as there were no records and no schema.
+    assert not parq_path.exists(), "Parquet file should not be created when no records are written."
+
+
+def test_read_iris_dataset_parquet(tmp_path: Path) -> None:
+    """Test reading a sample Parquet file containing the Iris dataset.
+
+    Dataset created using DuckDB with the following commands:
+
+    .. code-block:: sql
+
+        -- Load directly from the UCI repository
+        CREATE TABLE iris AS
+        SELECT * FROM read_csv_auto('https://archive.ics.uci.edu/ml/machine-learning-databases/iris/iris.data',
+            header=false,
+            columns={'sepal.length': 'DOUBLE', 'sepal.width': 'DOUBLE',
+                    'petal.length': 'DOUBLE', 'petal.width': 'DOUBLE', 'species': 'VARCHAR'});
+
+        -- Save as parquet with ZSTD compression
+        COPY iris TO 'iris_zstd.parquet' (FORMAT PARQUET, COMPRESSION 'ZSTD', COMPRESSION_LEVEL 9);
+
+    """
+    iris_parquet_path = Path(__file__).parent.parent / "_data" / "iris_zstd.parquet"
+
+    with ParquetReader(iris_parquet_path) as reader:
+        # Check Parquet file metadata
+        assert reader.parquet_file is not None
+        assert reader.parquet_file.schema_arrow.names == [
+            "sepal.length",
+            "sepal.width",
+            "petal.length",
+            "petal.width",
+            "species",
+        ]
+        assert reader.parquet_file.schema_arrow.types == [
+            "float64",
+            "float64",
+            "float64",
+            "float64",
+            "string",
+        ]
+        assert reader.parquet_file.metadata.num_rows == 150
+        assert reader.parquet_file.metadata.num_columns == 5
+        assert reader.parquet_file.metadata.num_row_groups == 1
+
+        # Read all records
+        records = list(reader)
+
+    assert len(records) == 150
+
+    descriptor = records[0]._desc
+    assert descriptor.name == "parquet/record"
+
+    # Also tests if the renaming of fields from dot notation to underscore notation works correctly.
+    assert descriptor.get_field_tuples() == (
+        ("float", "sepal_length"),
+        ("float", "sepal_width"),
+        ("float", "petal_length"),
+        ("float", "petal_width"),
+        ("string", "species"),
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import logging
 import typing
 
 import pytest
@@ -11,3 +12,26 @@ def reset_app_context() -> typing.Generator[None, None, None]:
     token = APP_CONTEXT.set(None)
     yield
     APP_CONTEXT.reset(token)
+
+
+@pytest.fixture(autouse=True)
+def reset_logging() -> typing.Generator[None, None, None]:
+    """Reset logging configuration between tests"""
+    # Store initial state
+    initial_handlers = logging.root.handlers.copy()
+    initial_level = logging.root.level
+
+    yield
+
+    # Remove any handlers added during the test
+    for handler in logging.root.handlers[:]:
+        if handler not in initial_handlers:
+            logging.root.removeHandler(handler)
+            if hasattr(handler, "close"):
+                try:
+                    handler.close()
+                except Exception:
+                    pass
+
+    # Reset level
+    logging.root.setLevel(initial_level)

--- a/tests/fieldtypes/test_digest.py
+++ b/tests/fieldtypes/test_digest.py
@@ -1,0 +1,97 @@
+import pytest
+
+from flow.record import RecordDescriptor
+
+# Valid digest values for testing
+MD5 = "d41d8cd98f00b204e9800998ecf8427e"
+SHA1 = "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+SHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+MD5_BYTES = bytes.fromhex(MD5)
+SHA1_BYTES = bytes.fromhex(SHA1)
+SHA256_BYTES = bytes.fromhex(SHA256)
+
+
+def test_digest_invalid_value() -> None:
+    """Test that setting an invalid digest value raises TypeError and does not modify the original value."""
+
+    TestRecord = RecordDescriptor(
+        "test/record",
+        [
+            ("digest", "digest"),
+        ],
+    )
+
+    record = TestRecord((MD5, SHA1, SHA256))
+    assert record.digest.md5 == MD5
+    assert record.digest.sha1 == SHA1
+    assert record.digest.sha256 == SHA256
+
+    with pytest.raises(TypeError, match=r"Invalid MD5 value 'aa', Incorrect hash length"):
+        record.digest.md5 = "aa"
+
+    with pytest.raises(TypeError, match=r"Invalid SHA-1 value 'aa', Incorrect hash length"):
+        record.digest.sha1 = "aa"
+
+    with pytest.raises(TypeError, match=r"Invalid SHA-256 value 'aa', Incorrect hash length"):
+        record.digest.sha256 = "aa"
+
+    with pytest.raises(TypeError, match=r"Incorrect binary MD5 hash length: 2, expected 16"):
+        record.digest.md5 = b"aa"
+
+    with pytest.raises(TypeError, match=r"Incorrect binary SHA-1 hash length: 2, expected 20"):
+        record.digest.sha1 = b"aa"
+
+    with pytest.raises(TypeError, match=r"Incorrect binary SHA-256 hash length: 2, expected 32"):
+        record.digest.sha256 = b"aa"
+
+    with pytest.raises(TypeError, match=r"Invalid MD5 value '.*', Non-hexadecimal digit found"):
+        record.digest.md5 = "z" * 32
+
+    with pytest.raises(TypeError, match=r"Invalid SHA-1 value '.*', Non-hexadecimal digit found"):
+        record.digest.sha1 = "z" * 40
+
+    with pytest.raises(TypeError, match=r"Invalid SHA-256 value '.*', Non-hexadecimal digit found"):
+        record.digest.sha256 = "z" * 64
+
+    assert record.digest.md5 == MD5
+    assert record.digest.sha1 == SHA1
+    assert record.digest.sha256 == SHA256
+
+
+@pytest.mark.parametrize(
+    "digest_value",
+    [
+        (MD5, SHA1, SHA256),
+        {"md5": MD5, "sha1": SHA1, "sha256": SHA256},
+        (MD5_BYTES, SHA1_BYTES, SHA256_BYTES),
+        {"md5": MD5_BYTES, "sha1": SHA1_BYTES, "sha256": SHA256_BYTES},
+    ],
+)
+def test_digest_initializers(digest_value: tuple | dict) -> None:
+    """Test that digest field can be set and retrieved from tuple, dictionary, and bytes initializers."""
+    TestRecord = RecordDescriptor(
+        "test/record",
+        [
+            ("digest", "digest"),
+        ],
+    )
+
+    record = TestRecord(digest=digest_value)
+    assert record.digest.md5 == MD5
+    assert record.digest.sha1 == SHA1
+    assert record.digest.sha256 == SHA256
+
+
+def test_digest_to_dict() -> None:
+    """Test that digest field can be iterated over to retrieve md5, sha1, and sha256 values."""
+
+    TestRecord = RecordDescriptor(
+        "test/record",
+        [
+            ("digest", "digest"),
+        ],
+    )
+
+    record = TestRecord(digest=(MD5, SHA1, SHA256))
+    assert dict(record.digest) == {"md5": MD5, "sha1": SHA1, "sha256": SHA256}

--- a/tests/fieldtypes/test_fieldtypes.py
+++ b/tests/fieldtypes/test_fieldtypes.py
@@ -479,7 +479,7 @@ def test_digest() -> None:
     assert record.digest.sha1 == sha1
     assert record.digest.sha256 == sha256
 
-    with pytest.raises(TypeError, match=r".*Invalid MD5.*Odd-length string"):
+    with pytest.raises(TypeError, match=r".*Invalid MD5.*Incorrect hash length"):
         record = TestRecord(("a", sha1, sha256))
 
     with pytest.raises(TypeError, match=r".*Invalid MD5.*Incorrect hash length"):


### PR DESCRIPTION
# Description
This PR adds support for reading and writing [Apache Parquet](https://parquet.apache.org/) files using [pyarrow](https://arrow.apache.org/docs/python/index.html). This allows `flow.record` tools like `rdump` to interact with the Parquet ecosystem, enabling efficient storage and integration with other data analysis tools.

# Implementation Details
The implementation introduces a new adapter in `flow/record/adapter/parquet.py` with the following features:

## ParquetWriter
- **Usage**: `rdump -w parquet://[PATH]?batch_size=[BATCH_SIZE]&compression=[COMPRESSION]` or `rdump -w output.parquet`
- **Compression**: Supports `snappy`, `gzip`, `brotli`, `zstd` (default), `lz4`, and `none`.
- **Schema Handling**:
    - Converts `flow.record` `RecordDescriptor` to PyArrow schemas.
    - Handles multiple schemas by splitting output into multiple files when the descriptor changes (since Parquet files strictly enforce a single schema).
    - Embeds `flow.record` descriptor metadata (`descriptor_name`, `descriptor_fields`) in the Parquet file metadata to ensure lossless round-tripping.

- **Type Mapping**: Maps `flow.record` types to their Arrow equivalents:
  - **Standard types**: boolean, float, string, etc.
  - **datetime** -> `timestamp('us', tz='UTC')`
  - **varint** -> `int64`
  - **digest** -> `struct<md5: binary, sha1: binary, sha256: binary>`
  - **path** -> `struct<path: string, path_type: uint8>`

## ParquetReader
- **Usage**: `rdump parquet://[PATH]` or `rdump dataset.parquet`
- **Filtering**: Supports column projection (fields and exclude arguments) to only read specific columns, leveraging Parquet's columnar nature for performance.
- **Schema Inference**: Reconstruction of RecordDescriptor from Arrow schema, using embedded metadata if available, or inferring from Arrow types if not.


## rdump

- **Column projection**: New CLI arguments have been added to `rdump` to exclude or include columns when reading Parquet files:
  - `--fields-read` or `-Fr`: columns to read, skipping reading of other columns
  - `--exclude-read` or `-Xr`: columns to exclude/skip for reading

## Related Improvements
- **Digest Field**: Enhanced `fieldtypes.digest` to support initialization from bytes and fixed a bug where invalid values could be set.
- An example Parquet file has been added to `tests/_data/iris-zstd.parquet` (git-lfs).
- An `.arrow` adapter has also been added as a bonus to this PR. It's basically the IPC streaming format for Apache Arrow which could be handy for future.

# Dependencies
pyarrow

```shell
pip install flow.record[parquet]
```

# Usage Example

```shell
# Writing to Parquet
rdump input.records -w "parquet://output.parquet?batch_size=10000&compression=zstd"
rdump input.records -w output.parquet

# Reading from Parquet
rdump parquet://input.parquet
rdump input.parquet

# Exclude a single columns from reading
rdump input.parquet -Xr data

# Only read the following columns, skipping other columns
rdump input.parquet -Fr src_ip,dst_ip
```

resolves #207