### PR TITLE
Fix ResourceWarning: unclosed database in SqliteReader and unit tests

### DIFF
--- a/flow/record/adapter/sqlite.py
+++ b/flow/record/adapter/sqlite.py
@@ -204,6 +204,11 @@ class SqliteReader(AbstractReader):
                 if match_record_with_context(record, selector, ctx):
                     yield record
 
+    def close(self) -> None:
+        if self.con:
+            self.con.close()
+        self.con = None
+
 
 class SqliteWriter(AbstractWriter):
     """SQLite writer."""


### PR DESCRIPTION
- SqliteReader was missing a close() method
- sqlite3.Connection as a context manager does NOT close the connection it only commits or rolls back the transaction.

<!--
Thank you for submitting a Pull Request. Please:
* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Include a description of the proposed changes and how to test them.

* After creation, associate the PR with an issue, under the development section.
  Or use closing keywords in the body during creation:
  E.G:
  * close(|s|d) #<nr>
  * fix(|es|ed) #<nr>
  * resolve(|s|d) #<nr>
-->

resolves #209
