### PR TITLE
Preserve metadata for multi timestamp records

### DIFF
--- a/flow/record/base.py
+++ b/flow/record/base.py
@@ -1121,12 +1121,12 @@ def iter_timestamped_records(record: Record) -> Iterator[Record]:
     # yield a new record for each ``datetime`` field assigned as ``ts``.
     record_name = record._desc.name
     for field in dt_fields:
-        ts_record = TimestampRecord(getattr(record, field.name), field.name)
-        # Preserve metadata from the original record so it isn't shadowed by
-        # the freshly-created TimestampRecord's None defaults in ChainMap.
-        ts_record._source = record._source
-        ts_record._classification = record._classification
-        ts_record._generated = record._generated
+        ts_record = TimestampRecord(
+            ts=getattr(record, field.name),
+            ts_description=field.name,
+            _source=record._source,
+            _classification=record._classification,
+            _generated=record._generated,
+        )
         # we extend ``ts_record`` with original ``record`` so TSRecord info goes first.
-        result = extend_record(ts_record, [record], name=record_name)
-        yield result
+        yield extend_record(ts_record, [record], name=record_name)

--- a/tests/record/test_multi_timestamp.py
+++ b/tests/record/test_multi_timestamp.py
@@ -162,8 +162,8 @@ def test_multi_timestamp_preserves_metadata() -> None:
     )
 
     test_record = TestRecord(
-        ctime=datetime(2020, 1, 1, 1, 1, 1),  # noqa: DTZ001
-        atime=datetime(2022, 11, 22, 13, 37, 37),  # noqa: DTZ001
+        ctime=datetime(2020, 1, 1, 1, 1, 1, tzinfo=timezone.utc),
+        atime=datetime(2022, 11, 22, 13, 37, 37, tzinfo=timezone.utc),
         data="test",
     )
     test_record._source = "/evidence/disk.E01"


### PR DESCRIPTION
Preserve metadata for multi timestamp records

Fixes metadata fields (`_source`, `_classification`, `_generated`) being set to null 
when `iter_timestamped_records()` expands a record into multi-timestamped records
by explicitly copying metadata fields to new `TimestampRecord` object.

Also fixes an issue with shadowed `record` variable in loop: use a separate result variable 
instead of reassigning `record` in the loop, which previously caused subsequent iterations 
to extend an already-extended record.

Includes a test to validate metadata values are retained. Due to using a new variable in the loop,
a change to  `test_multi_timestamp_descriptor_cache()` is required to adjust the expected cache misses
and hits. Because we are not mutating `record` each loop, we should only expect 1 cache miss.

fixes #218
<!--
Thank you for submitting a Pull Request. Please:
* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Include a description of the proposed changes and how to test them.

* After creation, associate the PR with an issue, under the development section.
  Or use closing keywords in the body during creation:
  E.G:
  * close(|s|d) #<nr>
  * fix(|es|ed) #<nr>
  * resolve(|s|d) #<nr>
-->
