### PR TITLE
Update docstrings for doctests

### DIFF
--- a/flow/record/base.py
+++ b/flow/record/base.py
@@ -1041,7 +1041,7 @@ def normalize_fieldname(field_name: str) -> str:
     This normalizes the name so it can still be used in flow.record.
     Reserved field_names are not normalized.
 
-    .. code-block:: text
+    Example::
 
         >>> normalize_fieldname("my-variable-name-with-dashes")
         'my_variable_name_with_dashes'

--- a/flow/record/fieldtypes/__init__.py
+++ b/flow/record/fieldtypes/__init__.py
@@ -103,11 +103,10 @@ def fieldtype_for_value(value: object, default: str = "string") -> str:
 
     Examples:
         >>> fieldtype_for_value("hello")
-        "string"
+        'string'
         >>> fieldtype_for_value(1337)
-        "varint"
+        'varint'
         >>> fieldtype_for_value(object(), None)
-        None
     """
     if isinstance(value, _bytes):
         return "bytes"

--- a/flow/record/fieldtypes/__init__.py
+++ b/flow/record/fieldtypes/__init__.py
@@ -763,14 +763,21 @@ class command(FieldType):
 
     Example:
 
-    .. code-block:: text
+    .. doctest::
 
-        'c:\\windows\\malware.exe /info'                      ->   windows_path('c:\\windows\\malware.exe) ('/info',)
-        '/usr/bin/env bash'                                   ->   posix_path('/usr/bin/env') ('bash',)
+        >>> command("c:\\windows\\malware.exe /info")
+        (executable='c:\\windows\\malware.exe', args=('/info',))
+        >>> command("c:\\windows\\malware.exe /info").executable
+        'c:\\windows\\malware.exe'
+        >>> command("c:\\windows\\malware.exe /info").args
+        ('/info',)
+
+        >>> command("/usr/bin/env bash -l")
+        (executable='/usr/bin/env', args=('bash', '-l'))
 
         # In this situation, the executable path needs to be quoted.
-        'c:\\user\\John Doe\\malware.exe /all /the /things'   ->   windows_path('c:\\user\\John')
-                                                                   ('Doe\\malware.exe, '/all', '/the', /things')
+        >>> command(r"c:\\user\\John Doe\\malware.exe /all /the /things")
+        (executable='c:\\user\\John', args=('Doe\\\\malware.exe', '/all', '/the', '/things'))
     """
 
     __executable: path

--- a/flow/record/fieldtypes/__init__.py
+++ b/flow/record/fieldtypes/__init__.py
@@ -101,7 +101,8 @@ def fieldtype_for_value(value: object, default: str = "string") -> str:
     Returns:
         str: the field type name or `default` if it cannot be derived
 
-    Examples:
+    Example::
+
         >>> fieldtype_for_value("hello")
         'string'
         >>> fieldtype_for_value(1337)
@@ -760,9 +761,7 @@ class command(FieldType):
         value: the string that contains the command and arguments
         path_type: When specified it forces the command to use a specific path type
 
-    Example:
-
-    .. code-block:: text
+    Example::
 
         >>> command("c:\\windows\\malware.exe /info")
         (executable='c:\\windows\\malware.exe', args=('/info',))

--- a/flow/record/fieldtypes/__init__.py
+++ b/flow/record/fieldtypes/__init__.py
@@ -765,12 +765,12 @@ class command(FieldType):
 
     .. code-block:: text
 
-        'c:\\windows\\malware.exe /info'                      ->   windows_path('c:\\windows\\malware.exe) ['/info']
-        '/usr/bin/env bash'                                   ->   posix_path('/usr/bin/env') ['bash']
+        'c:\\windows\\malware.exe /info'                      ->   windows_path('c:\\windows\\malware.exe) ('/info',)
+        '/usr/bin/env bash'                                   ->   posix_path('/usr/bin/env') ('bash',)
 
         # In this situation, the executable path needs to be quoted.
         'c:\\user\\John Doe\\malware.exe /all /the /things'   ->   windows_path('c:\\user\\John')
-                                                                   ['Doe\\malware.exe /all /the /things']
+                                                                   ('Doe\\malware.exe, '/all', '/the', /things')
     """
 
     __executable: path

--- a/flow/record/fieldtypes/__init__.py
+++ b/flow/record/fieldtypes/__init__.py
@@ -762,7 +762,7 @@ class command(FieldType):
 
     Example:
 
-    .. doctest::
+    .. code-block:: text
 
         >>> command("c:\\windows\\malware.exe /info")
         (executable='c:\\windows\\malware.exe', args=('/info',))


### PR DESCRIPTION
Noticed from #220 that the docstring of the command type didn't
represent the correct output anymore since we now also split the windows
arguments.

<!--
Thank you for submitting a Pull Request. Please:
* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Include a description of the proposed changes and how to test them.

* After creation, associate the PR with an issue, under the development section.
  Or use closing keywords in the body during creation:
  E.G:
  * close(|s|d) #<nr>
  * fix(|es|ed) #<nr>
  * resolve(|s|d) #<nr>
-->
