### PR TITLE
Add ISO 8601 string timestamp detection to fieldtypes

### DIFF
--- a/flow/record/fieldtypes/__init__.py
+++ b/flow/record/fieldtypes/__init__.py
@@ -29,6 +29,7 @@ from flow.record.base import FieldType, Record
 
 RE_NORMALIZE_PATH = re.compile(r"[\\/]+")
 RE_WINDOWS_PATH = re.compile(r"^[a-zA-Z]:[\\/]")
+RE_ISO8601_DATETIME = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?(Z|[\+-]\d{2}:\d{2})$")
 
 UTC = timezone.utc
 
@@ -110,6 +111,8 @@ def fieldtype_for_value(value: object, default: str = "string") -> str:
     if isinstance(value, _bytes):
         return "bytes"
     if isinstance(value, str):
+        if RE_ISO8601_DATETIME.match(value):
+            return "datetime"
         return "string"
     if isinstance(value, _float):
         return "float"

--- a/tests/fieldtypes/test_fieldtypes.py
+++ b/tests/fieldtypes/test_fieldtypes.py
@@ -813,6 +813,11 @@ def test_fieldtype_for_value() -> None:
     assert fieldtype_for_value(b"\r\n") == "bytes"
     assert fieldtype_for_value("hello world") == "string"
     assert fieldtype_for_value(datetime.now()) == "datetime"  # noqa: DTZ005
+    assert fieldtype_for_value("2026-03-19T14:20:23+00:00") == "datetime"
+    assert fieldtype_for_value("2026-03-19T14:20:23-01:00") == "datetime"
+    assert fieldtype_for_value("2026-03-19T14:20:23Z") == "datetime"
+    assert fieldtype_for_value("2026-03-19T14:20:23.123Z") == "datetime"
+    assert fieldtype_for_value("2026-03-19T14:20:23.123+01:00") == "datetime"
     assert fieldtype_for_value([1, 2, 3, 4, 5]) == "string"
     assert fieldtype_for_value([1, 2, 3, 4, 5], None) is None
     assert fieldtype_for_value(object(), None) is None


### PR DESCRIPTION
This PR adds `datetime` fieldtype detection for ISO 8601 strings. Not sure what the performance implications of this change are in regard to `fieldtype_for_value`.